### PR TITLE
Update

### DIFF
--- a/lua/shine/extensions/captainsmode/client.lua
+++ b/lua/shine/extensions/captainsmode/client.lua
@@ -1,62 +1,159 @@
-local Plugin = Plugin
+--[[
+	Captains Mode client.
+]]
+
+local Plugin = ...
+
 local Shine = Shine
 local SGUI = Shine.GUI
+local StringFormat = string.format
+local TableConcat = table.concat
+local Max = math.max;
 
 local CaptainMenu = {}
-local Players = {}
-local TeamNames = {"Marines", "Aliens"}
-local IsReady = false
-local MyTurn = false
-local Team1IsMarines = true
 
-function Plugin:OnFirstThink()
-	self:CallModuleEvent("OnFirstThink")
+function Plugin:Initialise()
+	self:BroadcastModuleEvent( "Initialise" )
+	
+	self.Enabled = true
+	self:ResetState()
+	
+	self.Window = nil
+	self.Created = false
+	self:CaptainMenuReset()	
+	
+	return true
 end
 
-function CaptainMenu:Create()
-	if self.Created then
-		return
-	end
+function Plugin:ResetState()
+	self.Logger:Trace( "Reset State") 
+	
+	self.Players = {}
+	self.IsReady = false
+	self.QueuePlayerUpdate = false
+	
+	self.myPickid = ""
+	self.myTeam = 0
+	self.myTeamName = ""
+	self.myTeamReady = false
+	self.Team1IsMarines = true
+	self.TeamStrings = {"Marines", "Aliens"}
+	self.TeamIndex = {1, 2}
+	self.TeamNames = {"Marines", "Aliens"}
+	self.CaptainNames = {"One","Two"}
+	self:SetTeamNames( )
+	
+	self.MatchStart = false
+	self.InProgress = false
+	
+end
 
+
+function Plugin:CaptainMenuReset()
+	self.Logger:Debug( "Reset Menu")
+	
+	self.myGUIObjs = nil
+	
+	self.PickListSort = {SortedColumn = 2, Descending = false}
+	self.PickList = nil
+	self.PickRows = {}
+	
+	self.TeamList = {}
+	self.TeamListSort = {{SortedColumn = 2, Descending = false},{SortedColumn = 2, Descending = false}}
+	self.TeamListRows= {{},{}}
+	self.TeamSkill = {0,0}
+	self.TeamCount = {0,0}
+	self.TeamNotice = {"",""}
+	
+	self.myTeamInput = nil
+	self.PickChange = false
+	
+end
+
+
+function Plugin:CaptainMenuInitialise()
+	if SGUI.IsValid( self.Window ) then 
+		self.Logger:Debug( "CaptainMenu Initialise: Window already exists." )
+		return 
+	end
+	self.Logger:Debug( "CaptainMenu Initialise" )	
+	
+	self:CaptainMenuReset()
+	
+	
 	local ScreenWidth = Client.GetScreenWidth()
 	local ScreenHeight = Client.GetScreenHeight()
+	self.PanelSize = Vector(ScreenWidth * 0.6 - 128, ScreenHeight * 0.8, 0)
 
-	local Window = SGUI:Create("TabPanel")
+	self.Window = SGUI:Create("TabPanel")
+	self.Window:SetDebugName( "CaptainsMenuWindow" )
+	self.Window:SetIsVisible(false)
+	self.Window:SetAnchor("TopLeft")
+	self.Window:SetSize(Vector(ScreenWidth * 0.6, ScreenHeight * 0.8, 0))
+	self.Window:SetPos(Vector(ScreenWidth * 0.3, ScreenHeight * 0.1, 0))
+	
+	-- If, for some reason, there's an error in a panel hook, then this is removed.
+	-- We don't want to leave the mouse showing if that happens.
+	self.Window:CallOnRemove( function()
+		if self.IgnoreRemove then return end
+		self.Logger:Debug("CaptainMenu Window Removed" )
 
-	self.Window = Window
-
-	Window:SetIsVisible(false)
-	Window:SetAnchor("TopLeft")
-	Window:SetSize(Vector(ScreenWidth * 0.6, ScreenHeight * 0.8, 0))
-	Window:SetPos(Vector(ScreenWidth * 0.3, ScreenHeight * 0.1, 0))
-
-	Window:CallOnRemove(
-		function()
-			if self.IgnoreRemove then
-				return
-			end
-
-			if self.Visible then
-				-- Make sure mouse is disabled in case of error.
-				SGUI:EnableMouse(false)
-				self.Visible = false
-			end
-
-			self.Created = false
-			self.Window = nil
+		if self.Visible then
+			SGUI:EnableMouse( false , self.Window )
+			self.Visible = false
 		end
-	)
 
-	self.Window = Window
+		self.Created = false 
+		self.Window = nil
+		self:CaptainMenuReset()
+		
+		if self.myTeam ~= 0 then
+			-- send end, but only if we were a captain.
+			self:SendNetworkMessage("RequestEndCaptains", {}, true) 
+		end
+		
+		self.Logger:Error( "CaptainsMode Failed.")
+	end )	
 
-	local PanelSize = Vector(ScreenWidth * 0.6 - 128, ScreenHeight * 0.8, 0)
-	Window:AddTab(
-		"Pick",
+	self.Window.OnPreTabChange = function( Window )
+	
+		if Window:GetIsVisible() == true then
+			self.Logger:Debug( "OnPreTabChange Window Visible")
+		else
+			self.Logger:Debug("OnPreTabChange Window NOT Visible" )
+		end 
+		
+		if not Window.ActiveTab then return end
+		local Tab = Window:GetActiveTab()
+		if not Tab or not Tab.Name then return end
+		
+		self.Logger:Debug("Window OnPreTabChange Tab %s", Tab.Name )
+		
+		if Tab.Name == "Pick" then
+			self.PickListSort.SortedColumn = self.PickList and self.PickList.SortedColumn or 3
+			self.PickListSort.Descending = self.PickList and self.PickList.Descending or false
+		end
+				
+		if Tab.Name == "Teams" then
+			-- Capture when the Teams tab goes away, and save the team name.
+			self.TeamListSort[1].SortedColumn = self.TeamList[1].SortedColumn or 3
+			self.TeamListSort[1].Descending = self.TeamList[1].Descending or false
+			self.TeamListSort[2].SortedColumn = self.TeamList[2].SortedColumn or 3 
+			self.TeamListSort[2].Descending = self.TeamList[2].Descending or false
+			self:UpdateTeamName() 
+		end
+		
+	end
+	
+
+	self.Window:AddTab ("Pick", 
 		function(Panel)
+			self.Logger:Debug("Populate Pick Window" )
+
 			local ListTitlePanel = Panel:Add("Panel")
 			ListTitlePanel:SetAnchor("TopLeft")
-			ListTitlePanel:SetSize(Vector(PanelSize.x * 0.96, PanelSize.y * 0.05, 0))
-			ListTitlePanel:SetPos(Vector(PanelSize.x * 0.02, PanelSize.y * 0.02, 0))
+			ListTitlePanel:SetSize(Vector(self.PanelSize.x * 0.96, self.PanelSize.y * 0.05, 0))
+			ListTitlePanel:SetPos(Vector(self.PanelSize.x * 0.02, self.PanelSize.y * 0.02, 0))
 
 			local ListTitleText = ListTitlePanel:Add("Label")
 			ListTitleText:SetAnchor("CentreMiddle")
@@ -65,45 +162,50 @@ function CaptainMenu:Create()
 			ListTitleText:SetTextAlignmentX(GUIItem.Align_Center)
 			ListTitleText:SetTextAlignmentY(GUIItem.Align_Center)
 
-			PickList = Panel:Add("List")
+			local PickList = Panel:Add("List")
 			PickList:SetAnchor("TopLeft")
-			PickList:SetSize(Vector(PanelSize.x * 0.96, PanelSize.y * 0.74, 0))
-			PickList:SetPos(Vector(PanelSize.x * 0.02, PanelSize.y * 0.09, 0))
-			PickList:SetColumns("NS2ID", "Name", "Skill")
-			PickList:SetSpacing(0.3, 0.55, 0.15)
+			PickList:SetSize(Vector(self.PanelSize.x * 0.96, self.PanelSize.y * 0.74, 0))
+			PickList:SetPos(Vector(self.PanelSize.x * 0.02, self.PanelSize.y * 0.09, 0))
+			PickList:SetColumns("NS2ID", "Name", "Marine", "Alien", "Room")
+			--PickList:SetSpacing(0.3, 0.55, 0.15)
+			PickList:SetSpacing(0.15, 0.50, 0.10, 0.10, 0.15)
 			PickList:SetNumericColumn(1)
-			PickList:SetNumericColumn(2)
+			PickList:SetNumericColumn(3)
+			PickList:SetNumericColumn(4)
 			PickList.TitlePanel = ListTitlePanel
 			PickList.TitleText = ListTitleText
+			
+			self.PickList = PickList
+			
+			self.PickList.SortedColumn = self.PickListSort.SortedColumn
+			self.PickList.Descending = self.PickListSort.Descending
+
+			
+			self.PickRows = {}
 
 			local CommandPanel = Panel:Add("Panel")
-			CommandPanel:SetSize(Vector(PanelSize.x, PanelSize.y * 0.13, 0))
-			CommandPanel:SetPos(Vector(0, PanelSize.y * 0.85, 0))
+			CommandPanel:SetSize(Vector(self.PanelSize.x, self.PanelSize.y * 0.13, 0))
+			CommandPanel:SetPos(Vector(0, self.PanelSize.y * 0.85, 0))
 
 			local CommandPanelSize = CommandPanel:GetSize()
 
 			local Turn = CommandPanel:Add("Label")
 			Turn:SetFont(Fonts.kAgencyFB_Large)
-			ListTitleText:SetAnchor("CentreMiddle")
 			Turn:SetPos(Vector(CommandPanelSize.x * 0.02, CommandPanelSize.y * 0.30, 0))
 			Turn:SetBright(true)
-
+			
 			local Pick = CommandPanel:Add("Button")
 			Pick:SetFont(Fonts.kAgencyFB_Large)
 			Pick:SetSize(Vector(CommandPanelSize.x * 0.2, CommandPanelSize.y, 0))
 			Pick:SetPos(Vector(CommandPanelSize.x * 0.78, 0, 0))
 			Pick:SetText("Pick")
 			Pick:SetEnabled(false)
+			Pick:SetIsVisible(false)
+			
+			self:GUI_AddObj( nil, "TurnText", Turn )
+			self:GUI_AddObj( nil, "PickButton", Pick )
 
-			if MyTurn then
-				Turn:SetColour(Colour(0, 1, 0, 1))
-				Turn:SetText("Your turn.")
-				Pick:SetIsVisible(true)
-			else
-				Turn:SetColour(Colour(1, 1, 1, 1))
-				Turn:SetText("Waiting for another captain...")
-				Pick:SetIsVisible(false)
-			end
+			self:UpdateTurnLabels(Turn, Pick)
 
 			function PickList:OnRowSelected(Index, Row)
 				Pick:SetEnabled(true)
@@ -114,234 +216,1063 @@ function CaptainMenu:Create()
 			end
 
 			function Pick.DoClick()
+			-- Row.Selected. caused an issue.
 				local Row = PickList:GetSelectedRow()
-				local SteamID = Row:GetColumnText(1)
-				Plugin:SendNetworkMessage("PickPlayer", {steamid = SteamID}, true)
-			end
-
-			for Index, Player in ipairs(Players) do
-				if Player.team == 3 then
-					PickList:AddRow(Player.steamid, Player.name, Player.skill)
+				if not SGUI.IsValid(Row) then
+					Pick:SetEnabled(false)
+					StartSoundEffect("sound/NS2.fev/common/invalid", 5)
+					return
 				end
+				local pickid = Row:GetData( "pickid" )
+				self:OnPickPlayer(pickid)
 			end
+			
+			self:PicklistUpdate()
+
 		end
-	)
+	)	
 
-	Window:AddTab(
-		"Teams",
+	self.Window:AddTab( "Teams" ,
 		function(Panel)
-			local ListItems = {}
-
-			local TeamStrings
-			if Team1IsMarines then
-				TeamStrings = {"Marines", "Aliens"}
-			else
-				TeamStrings = {"Aliens", "Marines"}
-			end
-
-			for i = 0, 1 do
+			self.Logger:Debug("Populate Teams Window" )
+			
+			for i = 1, 2 do
+				local col = i-1
 				local ListTitlePanel = Panel:Add("Panel")
-				ListTitlePanel:SetSize(Vector(PanelSize.x * 0.47, PanelSize.y * 0.05, 0))
+				ListTitlePanel:SetSize(Vector(self.PanelSize.x * 0.47, self.PanelSize.y * 0.05, 0))
 				ListTitlePanel:SetAnchor("TopLeft")
-				ListTitlePanel.Pos = Vector(PanelSize.x * (0.02 + 0.47 * i) + PanelSize.x * 0.02 * i, PanelSize.y * 0.02, 0)
+				ListTitlePanel.Pos = Vector(self.PanelSize.x * (0.02 + 0.47 * col) + self.PanelSize.x * 0.02 * col, self.PanelSize.y * 0.02, 0)
 				ListTitlePanel:SetPos(ListTitlePanel.Pos)
-
+		
 				local ListTitleText = ListTitlePanel:Add("Label")
 				ListTitleText:SetAnchor("CentreMiddle")
 				ListTitleText:SetFont(Fonts.kAgencyFB_Small)
 				ListTitleText:SetTextAlignmentX(GUIItem.Align_Center)
 				ListTitleText:SetTextAlignmentY(GUIItem.Align_Center)
-
-				if Plugin.Config.ShowMarineAlienToCaptains then
-					ListTitleText:SetText(string.format("%s (%s)", TeamNames[i + 1], TeamStrings[i + 1]))
-				else
-					ListTitleText:SetText(string.format("%s", TeamNames[i + 1]))
+				ListTitleText:SetText( self:FormatTeamHeading( i ) )
+				self:GUI_AddObj( i, "teamLabel", ListTitleText )
+				--self.TeamTitles[i] = ListTitleText
+				
+				-- Add Input for Setting My Team Name
+				if self.myTeam == i then
+					ListTitleText:SetAnchor("CenterRight")
+					ListTitleText:SetTextAlignmentX(GUIItem.Align_Max)
+		
+					local myTeamInput = SGUI:Create("TextEntry", ListTitlePanel)
+					--self.myGUIObjs["teamInput"] = myTeamInput
+					self:GUI_AddObj( nil, "teamInput", myTeamInput )
+					 
+					myTeamInput:SetDebugName( "CaptainsMyTeamName" )
+					myTeamInput:SetAnchor("CenterLeft")
+					--myTeamInput:SetTextAlignmentY(GUIItem.Align_Center)
+					myTeamInput:SetFont(Fonts.kAgencyFB_Small)
+					--myTeamInput:SetPos(Vector(-160, -5, 0))
+					--myTeamInput:SetSize(Vector(320, 32, 0))
+					myTeamInput:SetSize( ListTitlePanel:GetSize() * 0.5 )
+					--myTeamInput:SetBorderSize(  )
+					myTeamInput:SetText(StringFormat("%s", self.TeamNames[i]))
+					myTeamInput.MaxLength = 255
+		
+					function myTeamInput.OnLoseFocus()
+						-- this never gets called when the tab changes.
+						if not SGUI.IsValid(myTeamInput) then return end
+						if not myTeamInput:HasFocus() then return end
+						self:UpdateTeamName(myTeamInput)
+					end
+		
+					function myTeamInput.OnEnter()
+						self:UpdateTeamName(myTeamInput)
+					end
+					
+					function myTeamInput.OnEscape()
+						self:UpdateTeamName(myTeamInput)
+					end
+					
 				end
-
+				
+		
 				local List = Panel:Add("List")
 				List:SetAnchor("TopLeft")
-				List.Pos = Vector(PanelSize.x * (0.02 + 0.47 * i) + PanelSize.x * 0.02 * i, PanelSize.y * 0.09, 0)
+				List.Pos = Vector(self.PanelSize.x * (0.02 + 0.47 * col) + self.PanelSize.x * 0.02 * col, self.PanelSize.y * 0.09, 0)
 				List:SetPos(List.Pos)
-				List:SetColumns("Name", "Skill")
-				List:SetSpacing(0.7, 0.3)
-				List:SetSize(Vector(PanelSize.x * 0.47, PanelSize.y * 0.69, 0))
-				List:SetNumericColumn(1)
+				List:SetColumns("Name", "Skill", "Room")
+				--List:SetSpacing(0.7, 0.3)
+				List:SetSpacing(0.6, 0.2, 0.2)
+				List:SetSize(Vector(self.PanelSize.x * 0.47, self.PanelSize.y * 0.69, 0))
+				--List:SetNumericColumn(1)
 				List:SetNumericColumn(2)
 				List.ScrollPos = Vector(0, 32, 0)
 				List.TitlePanel = ListTitlePanel
-				List.TitleText = ListTitleText
+		
+				self.TeamList[i] = List
+				self.TeamListRows[i] = {}
 
-				ListItems[i] = List
+				self.TeamList[i].SortedColumn = self.TeamListSort[i].SortedColumn or 1
+				self.TeamList[i].Descending = self.TeamListSort[i].Descending or false
+
+
+				
+				local Padding = Vector2( 5, 0 )
+				local ZeroVector = Vector2( 0, 0 )
+				local LastColumn = Vector2( 0, 0 )
+				
+				local BottomRow = Panel:Add("Panel")
+				BottomRow:SetSize(Vector(self.PanelSize.x * 0.47, self.PanelSize.y * 0.05, 0))
+				BottomRow:SetAnchor("TopLeft")
+				BottomRow.Pos = Vector(List.Pos.x, self.PanelSize.y * 0.79, 0)
+				BottomRow:SetPos(BottomRow.Pos)
+				--BottomRow.Background:SetColor( Colour( 255, 0, 0 ) )
+				--BottomRow.Background:SetColor( Panel.Background:GetColor()  )
+				BottomRow.Background:SetColor( Colour( 0.3, 0.3, 0.3, 1 ) )
+				
+				local TextObjs = {} 
+				BottomRow.TextObjs = TextObjs
+				BottomRow.ColumnText = {}
+				BottomRow.ColumnText[1] = ""
+				BottomRow.ColumnText[2] = "0"
+				BottomRow.ColumnText[3] = "0"
+				
+				-- Copy spacing from List header.
+				local X = BottomRow:GetSize().x
+				local Spacing = {}
+				for j = 1, #List.HeaderSizes do
+					Spacing[j] = Vector2(List.HeaderSizes[j] * X , 0 )
+				end 
+				for j = 1, #Spacing do
+					local TextObj = BottomRow:Add("Label")
+					TextObj:SetAnchorFraction( 0, 0.5 )
+					TextObj:SetFont(Fonts.kAgencyFB_Small)
+					TextObj:SetTextAlignmentY(GUIItem.Align_Center)
+					TextObj:SetText( BottomRow.ColumnText[j] )
+					
+					TextObj:SetPos( Padding + (Spacing[j-1] or ZeroVector) + LastColumn )
+					LastColumn = TextObj:GetPos()
+					TextObjs[j] = TextObj 
+				end 
+				--self.TeamSkillText[i] = TextObjs
+				
+				self:GUI_AddObj( i, "bottomMessage", TextObjs[1] )
+				self:GUI_AddObj( i, "bottomSkill", TextObjs[2] )
+				self:GUI_AddObj( i, "bottomCount", TextObjs[3] )
+				
+				-- BottomRow.TextObjs[ i ]:SetAutoSize( UnitVector( Percentage( Size * 100 ), Percentage.ONE_HUNDRED ) )				
+				
 			end
 
-			local TeamName = Panel:Add("Button")
-			TeamName:SetFont(Fonts.kAgencyFB_Small)
-			TeamName:SetSize(Vector(PanelSize.x * 0.3, PanelSize.y * 0.06, 0))
-			TeamName:SetPos(Vector(PanelSize.x * 0.35, PanelSize.y * 0.80, 0))
-			TeamName:SetText("Team Name")
+			if self.myTeam == 0 then
+				-- Not-A-Captain. Add Close button.			
+				local Ready = Panel:Add("Button")
+				Ready:SetFont(Fonts.kAgencyFB_Large)
+				Ready:SetSize(Vector(self.PanelSize.x * 0.3, self.PanelSize.y * 0.1, 0))
+				Ready:SetPos(Vector(self.PanelSize.x * 0.35, self.PanelSize.y * 0.88, 0))
+				Ready:SetText( "Close" )
+			
+				function Ready.DoClick()
+					self:SetIsVisible(false)
+					self:Notify( "Captains window hidden. Use !showteams to see it again.")
+				end
+				
+	
+			else
+				-- Set a Captain Ready button
+				local Ready = Panel:Add("Button")
+				Ready:SetFont(Fonts.kAgencyFB_Large)
+				Ready:SetSize(Vector(self.PanelSize.x * 0.3, self.PanelSize.y * 0.1, 0))
+				Ready:SetPos(Vector(self.PanelSize.x * 0.35, self.PanelSize.y * 0.88, 0))
 
-			function TeamName.DoClick()
-				self:AskforTeamName()
-			end
+				Ready:SetText( self.myTeamReady and "Not Ready" or "Ready")
+			
+				function Ready.DoClick()
+					self.myTeamReady = not self.myTeamReady
+					Ready:SetText( self.myTeamReady and "Not Ready" or "Ready")
+					self:SendNetworkMessage("SetReady", {ready = self.myTeamReady}, true)
+				end
+				self:GUI_AddObj( nil, "ReadyButton", Ready )
 
-			local Ready = Panel:Add("Button")
-			Ready:SetFont(Fonts.kAgencyFB_Large)
-			Ready:SetSize(Vector(PanelSize.x * 0.3, PanelSize.y * 0.1, 0))
-			Ready:SetPos(Vector(PanelSize.x * 0.35, PanelSize.y * 0.88, 0))
-			Ready:SetText("Ready")
-
-			function Ready.DoClick()
-				if IsReady then
-					IsReady = false
-					Ready:SetText("Ready")
+				-- Add Trade Player button
+				local Trade = Panel:Add("Button")
+				Trade:SetFont(Fonts.kAgencyFB_Large)
+				--Trade:SetSize(Vector(self.PanelSize.x * 0.3, self.PanelSize.y * 0.1, 0))
+				Trade:SetSize(Vector(self.PanelSize.x * 0.20,self.PanelSize.y * 0.1, 0))
+				--Trade:SetPos(Vector(self.PanelSize.x * 0.35,self.PanelSize.y * 0.88, 0))
+				Trade:SetText( "Give Player" )
+				Trade:SetEnabled(false)
+				
+				Trade:SetIsVisible(self:PickingDone())
+				
+				if self.myTeam == 1 then
+					Trade:SetPos(Vector(
+						self.PanelSize.x * (0.02 )
+					, 	self.PanelSize.y * 0.88, 0
+						))				
 				else
-					IsReady = true
-					Ready:SetText("Not Ready")
+					Trade:SetPos(Vector(
+						(self.PanelSize.x * (0.02 + 0.47) + self.PanelSize.x * 0.02) 
+						+ (self.PanelSize.x * 0.47) 
+						- (self.PanelSize.x * 0.20)
+						, 	self.PanelSize.y * 0.88, 0
+						))				
 				end
-				Plugin:SendNetworkMessage("SetReady", {ready = IsReady}, true)
-			end
+								
+				self.TeamList[self.myTeam].OnRowSelected = function(List, Index, Row)
+					if not Trade:GetIsVisible() and self:PickingDone() then
+						Trade:SetIsVisible(true)
+					end
+					local pickid = Row:GetData( "pickid" )
+					-- Activate Trade if they didn't click on themselves.
+					if self.myPickid ~= pickid then 
+						Trade:SetEnabled(true)
+					end  
+				end
 
-			for Index, Player in ipairs(Players) do
-				if Player.team == 1 then
-					ListItems[0]:AddRow(Player.name, Player.skill)
-				elseif Player.team == 2 then
-					ListItems[1]:AddRow(Player.name, Player.skill)
-				end
+				self.TeamList[self.myTeam].OnRowDeselected = function(List, Index, Row)
+					Trade:SetEnabled(false)
+				end	
+				
+				function Trade.DoClick()
+				-- Row.Selected. caused an issue.
+					local Row = self.TeamList[self.myTeam]:GetSelectedRow()
+					if not SGUI.IsValid(Row) then
+						Trade:SetEnabled(false)
+						StartSoundEffect("sound/NS2.fev/common/invalid", 5) 
+						return
+					end
+					local pickid = Row:GetData( "pickid" )
+					if self.myPickid == pickid then
+						Trade:SetEnabled(false)
+						StartSoundEffect("sound/NS2.fev/common/invalid", 5) 
+						return
+					end
+					self:OnTradePlayer(pickid)
+				end		
+					
 			end
+		
+			self:TeamListUpdate()
+			
 		end
 	)
-
-	Window:AddTab(
+	
+	-- add Cancel tab 
+	self.Window:AddTab(
 		"Cancel",
 		function(Panel)
+			self.Logger:Debug("Populate Cancel Window" )
+			
 			local Cancel = Panel:Add("Button")
 			Cancel:SetFont(Fonts.kAgencyFB_Large)
-			Cancel:SetSize(Vector(PanelSize.x * 0.3, PanelSize.y * 0.1, 0))
-			Cancel:SetPos(Vector(PanelSize.x * 0.35, PanelSize.y * 0.45, 0))
+			Cancel:SetSize(Vector(self.PanelSize.x * 0.3, self.PanelSize.y * 0.1, 0))
+			Cancel:SetPos(Vector(self.PanelSize.x * 0.35, self.PanelSize.y * 0.45, 0))
 			Cancel:SetText("Cancel Captains")
 
 			function Cancel.DoClick()
-				Plugin:SendNetworkMessage("RequestEndCaptains", {}, true)
+				self:SendNetworkMessage("RequestEndCaptains", {}, true)
+				if self.myTeam == 0 then
+					self:SetIsVisible( false )
+				end
 			end
+
 		end
 	)
+		
+	self.CaptainMenuCreated = true
+	
+	self.Logger:Debug( "CaptainMenu Initialise done" )
 
-	self.Created = true
 end
 
-function CaptainMenu:AskforTeamName()
-	if self.TeamNameCreated then
+
+function Plugin:PicklistUpdate()
+	self.Logger:Debug("Picklist Update start" )		
+
+	if not SGUI.IsValid(self.PickList) then 
+		self.Logger:Debug("Picklist Update EMPTY" )
+		return 
+	end
+	local ExistingPlayers = {}
+
+	for _, Ent in pairs( self.Players ) do
+		self:PickListAdd( Ent )
+		ExistingPlayers[ Ent.pickid ] = true
+	end
+
+
+	for pickid, Row in pairs( self.PickRows ) do
+		if not ExistingPlayers[ pickid ] then
+			self:PickListRemove( pickid, Row.Index, Row:GetColumnText(2) )
+		end
+	end
+	
+	self.Logger:Debug("Picklist Update end" )
+	
+end	
+
+function Plugin:PickListAdd( Ent )
+	
+	local pickTeam = Ent.pick or 0
+	local isPickable = Ent.isPickable or false
+	
+	local Row = self.PickRows[ Ent.pickid ]
+	
+	if SGUI.IsValid( Row ) then
+		if pickTeam == 0 and isPickable then 
+			Row:SetColumnText( 1, tostring( Ent.steamid ) )
+			Row:SetColumnText( 2, Ent.name )
+			Row:SetColumnText( 3, tostring( Ent.marine ) )
+			Row:SetColumnText( 4, tostring( Ent.alien) )
+			Row:SetColumnText( 5, Plugin:GetTeamName( Ent.team, true ) )
+			Row:SetColumnText( 6, tostring( Ent.pickid ) )
+			Row:SetData( "pickid" , Ent.pickid )
+			Row:SetTooltip( Ent.skillText )
+			self.Logger:Trace("Picklist Updated [%s]%s", Ent.pickid, Ent.name )
+			
+			if not (isPickable) then 
+				Row:SetTextOverride( 4, {
+						Font = Fonts.kAgencyFB_Small,
+						TextScale = GetScaledVector(),
+						Colour = Colour( 255, 0, 0 )
+					} )
+			end
+			
+			
+		else
+			-- remove them if they were picked.
+			self.PickList:RemoveRow( Row.Index )
+			self.PickRows[ Ent.pickid ] = nil
+			self.Logger:Trace("Picklist Removed [%s]%s", Ent.pickid, Ent.name )	
+		end
+		return
+	elseif pickTeam ~= 0 or not isPickable then
 		return
 	end
 
-	local Window = SGUI:Create("Panel")
-	local ScreenHeight = Client.GetScreenHeight()
-	Window:SetAnchor("CentreMiddle")
-	Window:SetSize(Vector(400, 200, 0))
-	Window:SetPos(Vector(-200, -ScreenHeight / 2 + ScreenHeight * 0.02, 0))
+	self.PickRows[ Ent.pickid ] = self.PickList:AddRow( 
+				  Ent.steamid
+				, Ent.name
+				, Ent.marine
+				, Ent.alien
+				, Plugin:GetTeamName( Ent.team, true )
+				)
+	self.PickRows[ Ent.pickid ]:SetData("pickid",Ent.pickid )
+	self.PickRows[ Ent.pickid ]:SetTooltip( Ent.skillText )
 
-	Window:AddTitleBar("Team name")
-
-	function Window.CloseButton.DoClick()
-		Shine.AdminMenu:DontDestroyOnClose(Window)
-		Window:Destroy()
-		self.TeamNameCreated = false
+	if not (isPickable) then 
+		self.PickRows[ Ent.pickid ]:SetTextOverride( 4, {
+				Font = Fonts.kAgencyFB_Small,
+				TextScale = GetScaledVector(),
+				Colour = Colour( 255, 0, 0 )
+			} )
 	end
 
-	local Label = SGUI:Create("Label", Window)
-	Label:SetAnchor("CentreMiddle")
-	Label:SetFont(Fonts.kAgencyFB_Small)
-	Label:SetBright(true)
-	Label:SetText("Please type in your new teamname.")
-	Label:SetPos(Vector(0, -40, -25))
-	Label:SetTextAlignmentX(GUIItem.Align_Center)
-	Label:SetTextAlignmentY(GUIItem.Align_Center)
+	self.Logger:Trace("Picklist Added [%s]%s",  Ent.pickid, Ent.name )	
+end
 
-	local Input = SGUI:Create("TextEntry", Window)
-	Input:SetAnchor("CentreMiddle")
-	Input:SetFont(Fonts.kAgencyFB_Small)
-	Input:SetPos(Vector(-160, -5, 0))
-	Input:SetSize(Vector(320, 32, 0))
+function Plugin:PickListRemove( pickid, index, playerName)
+	if team == 0 then return end
+	if SGUI.IsValid(self.PickList ) then
+		self.PickList:RemoveRow( index ) 
+	end 
+	self.PickRows[ pickid ] = nil
+	self.Logger:Trace("Picklist Removed [%s]%s", pickid, playerName )	
+end
 
-	local OK = SGUI:Create("Button", Window)
-	OK:SetAnchor("CentreMiddle")
-	OK:SetSize(Vector(128, 32, 0))
-	OK:SetPos(Vector(-64, 40, 0))
-	OK:SetFont(Fonts.kAgencyFB_Small)
-	OK:SetText("OK")
-
-	self.TeamNameCreated = true
-
-	function OK.DoClick()
-		local Text = Input:GetText()
-		if Text and Text:len() > 0 then
-			Plugin:SendNetworkMessage("SetTeamName", {teamname = Text}, true)
+function Plugin:PickingDone()
+	local Exists = false
+	local HavePickable = false
+	for Index, Player in ipairs(self.Players) do
+		Exists = true
+		if Player.pick == 0 and Player.isPickable then
+			HavePickable  = true
+			break
 		end
-		Window:Destroy()
-		self.TeamNameCreated = false
+	end	
+	return Exists and not HavePickable 
+end
+
+
+function Plugin:TeamListUpdate()
+
+	self.Logger:Debug("TeamList Update start" )
+	if not SGUI.IsValid(self.TeamList and self.TeamList[1]) 
+	or not SGUI.IsValid(self.TeamList and self.TeamList[2]) 
+	then
+		self.Logger:Debug("TeamList Update EMPTY" )
+		return 
+	end
+	local ExistingPlayers = {}
+	
+	if self.PickChange then
+		-- reset team list
+		self.TeamList[1]:Clear()
+		self.TeamList[2]:Clear()
+		self.TeamListRows= {}
+		self.TeamListRows[1] = {}
+		self.TeamListRows[2] = {}
+		self.PickChange = false	
+	end
+	
+	self.TeamSkill = {0,0}
+	self.TeamCount = {0,0}
+
+	for _, Ent in pairs( self.Players ) do
+		self:TeamListAdd( Ent )
+		ExistingPlayers[ Ent.pickid ] = true
+	end
+
+	for team, t_list in pairs( self.TeamListRows ) do
+		for pickid, Row in pairs( t_list ) do
+			if not ExistingPlayers[ pickid ] then
+				self:TeamListRemove( team, pickid, Row.Index, Row:GetColumnText(1) )
+			end
+		end
+	end
+
+	if  self.TeamCount[1] > (self.TeamCount[2]+1) then
+		self.TeamNotice[1] = "Select a player to give the other team."
+		self.TeamNotice[2] = "Wait for a player from the other team."
+		local skillDiff = self.TeamSkill[1] - self.TeamSkill[2]
+		if skillDiff > 0 then
+			skillDiff = skillDiff / 2
+			if skillDiff > 0 then 
+				self.TeamNotice[1] = self.TeamNotice[1] ..  StringFormat( " Around Skill: %i", skillDiff )
+			end
+		end   
+		
+	elseif self.TeamCount[2] > (self.TeamCount[1]+1) then
+		self.TeamNotice[2] = "Select a player to give the other team."
+		self.TeamNotice[1] = "Wait for a player from the other team."
+		local skillDiff = self.TeamSkill[1] - self.TeamSkill[2]
+		if skillDiff > 0 then
+			skillDiff = skillDiff / 2
+			if skillDiff > 0 then 
+				self.TeamNotice[2] = self.TeamNotice[2] ..  StringFormat( " Around Skill: %i", skillDiff )
+			end
+		end   
+	end
+		
+	for i = 1, 2 do
+		self:GUI_SetText( i, "bottomSkill", "%s", self.TeamSkill[i] )
+		self:GUI_SetText( i, "bottomCount", "%s", self.TeamCount[i] )
+		self:GUI_SetText( i, "bottomMessage", "%s", self.TeamNotice[i] )
+	end
+	self.Logger:Debug("TeamList Update End" )
+end
+
+
+function Plugin:TeamListAdd( Ent )
+	local pickTeam = Ent.pick or 0
+	if pickTeam  == 0 then return end
+
+	if self.TeamList == nil 
+	or not SGUI.IsValid(self.TeamList[1])
+	or not SGUI.IsValid(self.TeamList[2]) 
+	then
+		return
+	end
+	if self.TeamListRows[pickTeam ] == nil then return end
+	local ptSkill = ( self.TeamIndex[pickTeam] == 1 and Ent.marine or Ent.alien)
+
+	local Row = self.TeamListRows[pickTeam ][ Ent.pickid ]
+	if SGUI.IsValid( Row ) then
+		Row:SetColumnText( 1, Ent.name )
+		Row:SetColumnText( 2, tostring( ptSkill ) )
+		Row:SetColumnText( 3, Plugin:GetTeamName( Ent.team, true ) )
+		Row:SetData("pickid", Ent.pickid)
+		Row:SetTooltip( Ent.skillText )
+		self.Logger:Trace("Team %s Updated [%s]%s", pickTeam, Ent.pickid, Ent.name )
+		self.TeamSkill[pickTeam] = self.TeamSkill[pickTeam] + ptSkill
+		self.TeamCount[pickTeam] = self.TeamCount[pickTeam] + 1
+		
+		if not (Ent.isPickable) then
+			local Font, Scale = SGUI.FontManager.GetHighResFont( "kAgencyFB", 27 )
+			Row:SetTextOverride( 3, {
+					Font = Font,
+					TextScale = Scale,
+					Colour = Colour( 255, 0, 0 )
+				} )
+		end
+		
+		return
+	end
+	Row = self.TeamList[pickTeam]:AddRow( Ent.name, ptSkill, Plugin:GetTeamName( Ent.team, true ))
+	self.TeamListRows[pickTeam][ Ent.pickid ] = Row 
+	Row:SetData("pickid", Ent.pickid)			
+	Row:SetTooltip( Ent.skillText )
+	self.Logger:Trace("Team %s Added [%s]%s", pickTeam, Ent.pickid, Ent.name )
+	self.TeamSkill[pickTeam] = self.TeamSkill[pickTeam] + ptSkill
+	self.TeamCount[pickTeam] = self.TeamCount[pickTeam] + 1
+	if not (Ent.isPickable) then
+		local Font, Scale = SGUI.FontManager.GetHighResFont( "kAgencyFB", 27 )
+		Row:SetTextOverride( 3, {
+				Font = Font,
+				TextScale = Scale,
+				Colour = Colour( 255, 0, 0 )
+			} )
+	end
+	
+end
+
+function Plugin:TeamListRemove( team , ID, index, playerName )
+	if team == 0 then return end
+	if SGUI.IsValid(self.TeamList[team]) then
+		self.TeamList[team]:RemoveRow( index )
+	end 
+	self.TeamListRows[team][ ID ] = nil
+	self.Logger:Trace("Team %s Removed [%s]%s", team, ID, playerName )	
+end
+	
+
+function Plugin:UpdatePlayers(force)
+
+	-- this worked too well. when the window appears, the list is empty.
+	if not force then
+		if not (SGUI.IsValid( self.Window ) and self.Window:GetIsVisible() == true ) then
+			self.Logger:Debug( "UpdatePlayers Not Window:Not Visible" )
+			return
+		end
+	end
+	
+	self.Logger:Debug( "UpdatePlayers" )
+	self:PicklistUpdate()
+	self:TeamListUpdate()
+
+end
+
+
+function Plugin:UpdateTurn()
+	if self.myTeam == 0 then return end
+	
+	local Turn = self:GUI_GetObj( 0, "TurnText" )
+	local Pick = self:GUI_GetObj( 0, "PickButton" )
+	
+	if  SGUI.IsValid( Turn ) 
+	and SGUI.IsValid( Pick ) 
+	and Turn:GetIsVisible() then
+		self.Logger:Debug( "UpdateTurn Screen Text" )
+		if (self:UpdateTurnLabels(Turn, Pick) ) then
+		-- If Pick is enabled && something was selected. See if that row still exists.
+			local Row = self.PickList.GetSelectedRow and self.PickList:GetSelectedRow()
+			if not SGUI.IsValid(Row) then
+				Pick:SetEnabled(false)
+			end
+		end
+		-- InvalidateLayout will cause the window to refresh in the next refresh frame.
+		self.Window:InvalidateLayout( )
+		return
+	end
+	
+end
+
+function Plugin:UpdateTurnLabels(Turn, Pick)
+	if (Plugin.dt.CaptainTurn == 0 or self.myTeam == 0) then
+		return false
+	end
+	if (Plugin.dt.CaptainTurn == self.myTeam) then
+		Turn:SetColour(Colour(0, 1, 0, 1))
+		Turn:SetText("Your turn.")
+		Pick:SetIsVisible(true)
+		return true
+	else
+		Turn:SetColour(Colour(1, 1, 1, 1))
+		Turn:SetText("Waiting for another captain...")
+		Pick:SetIsVisible(false)
+		return false
 	end
 end
 
-function Plugin:Initialise()
-	CaptainMenu:Create()
 
-	self.Enabled = true
 
-	return true
+function Plugin:SetIsVisible( show , tab)
+	-- re-init the window if it crashed.
+	self:CaptainMenuInitialise() 
+
+	if not SGUI.IsValid( self.Window ) then
+		self.Logger:Debug( "SetIsVisible Window invalid" ) 
+ 		return 
+	end
+	
+	if tab and tab > 0 and tab < 3 then
+		local haveTab = self.Window:SetSelectedTab( self.Window.Tabs[ tab ] ) 
+		if haveTab then self.Logger:Debug( "SetIsVisible Tab %s", self.Window.Tabs[ tab ].Name ) end 
+	end
+	self.Window:SetIsVisible( show )
+	self.Window:InvalidateLayout( true )
+	SGUI:EnableMouse(show,self.Window)
+	self.Logger:Debug( "SetIsVisible done %s", show and "show" or "hide" )
+	self.Visible = show 
+	
 end
+
+function Plugin:ShowTeamMenu()
+	if not self.InProgress then return end
+	
+	self.Logger:Debug( "ShowTeamMenu" )
+	self:SetIsVisible( true , 2 )
+end
+
+function Plugin:OnUnsetReady()
+	self.Logger:Debug( "Plugin:OnUnsetReady")
+	if self.myTeam == 0 then return end
+	
+	Client.WindowNeedsAttention()
+	self.myTeamReady = false
+	self:GUI_SetText( nil, "ReadyButton", self.myTeamReady and "Not Ready" or "Ready" )
+	self.Window:InvalidateLayout( )
+	StartSoundEffect("sound/NS2.fev/marine/voiceovers/soldier_lost")
+	self.TeamNotice[self.myTeam] = "Player List Updated"
+	self:ShowTeamMenu()
+end 
+
+function Plugin:ReceiveUnsetReady(Data)
+	self.Logger:Debug( "Plugin:ReceiveUnsetReady")
+	self.ProcessUnsetReady = true
+end
+
+
+function Plugin:ReceiveShowTeamMenu(Data)
+	self.Logger:Debug( "Plugin:ReceiveShowTeamMenu") 
+	self:ShowTeamMenu()
+end
+
+function Plugin:ReceiveHideMouse(Data)
+	self.Logger:Debug( "Plugin:ReceiveHideMouse")
+	SGUI:EnableMouse(false)	
+end
+
+
+function Plugin:FormatTeamHeading(team)
+	local Text
+	
+	if self.myTeam == 0 then
+	-- show Captain names to everyone else for Team Names.
+		Text = StringFormat("Team- %s", self.CaptainNames[team])
+		
+	elseif Plugin.Config.ShowMarineAlienToCaptains then
+		Text = StringFormat("%s (%s)", self.TeamNames[team], self.TeamStrings[team])
+	else
+		Text = StringFormat("%s", self.TeamNames[team])
+	end
+	self.Logger:Trace("FormatTeamHeading text [%s]", Text )
+	return Text
+end
+
+-- Update TeamName from SGUI
+function Plugin:UpdateTeamName(Input)
+	self.Logger:Debug( "UpdateTeamName" )
+	teamInput = Input
+	if teamInput == nil then
+		teamInput = self:GUI_GetObj( nil, "teamInput" )
+		if not SGUI.IsValid(teamInput)  then 
+			self.Logger:Debug( "UpdateTeamName not IsValid" )
+		end
+	end
+	if not SGUI.IsValid(teamInput) then return end
+	local Text = teamInput:GetText()
+	if self.myTeam == 0  then return end
+	self.Logger:Debug( "UpdateTeamName have team %s ", self.myTeam  ) 
+
+	if Text and Text:len() > 0
+	and Text ~= self.TeamNames[ self.myTeam]
+	then
+		self:SendNetworkMessage("SetTeamName", {teamname = Text}, true)
+		self.Logger:Debug( "Send Team Name %s ", Text ) 
+		self.TeamNames[self.myTeam] = Text
+		self:GUI_SetText( self.myTeam, "teamLabel", self:FormatTeamHeading(self.myTeam) )
+	end
+
+end
+
+function Plugin:GUI_AddObj( team, name, obj )
+	self.myGUIObjs = self.myGUIObjs or {} 
+	if team and (team == 1 or team == 2) then
+		self.myGUIObjs["team"] = self.myGUIObjs["team"] or  {}
+		self.myGUIObjs["team"][team] = self.myGUIObjs["team"][team] or {}
+		self.myGUIObjs["team"][team][name] = obj
+		self.Logger:Trace("AddObj add team %s %s", team, name )
+	else
+		self.myGUIObjs[name] = obj
+		self.Logger:Trace("AddObj add %s", name )
+	end
+end
+
+function Plugin:GUI_GetObj( team, name )
+	self.myGUIObjs = self.myGUIObjs or {}
+	local myObj = nil
+	if team and (team == 1 or team == 2) then
+		self.Logger:Debug("Plugin:GUI:GetObj team %s", team)
+		teamObj = self.myGUIObjs["team"]
+		if not (teamObj and teamObj[team]) then 
+			self.Logger:Debug("Plugin:GUI:GetObj team not found") 
+			return myObj
+		end
+		myObj = teamObj[team][name]
+		self.Logger:Debug("Plugin:GUI:GetObj team %s %s", team, name )
+	else
+		myObj = self.myGUIObjs[name] 
+		self.Logger:Debug("Plugin:GUI:GetObj %s", name )
+	end
+	-- We will do this when we use it anyway. so skip IsValid for now.
+	if not SGUI.IsValid(myObj) then
+		self.Logger:Debug("Plugin:GUI:GetObj object not IsValid.")
+		return myObj
+	end
+	return myObj
+end
+
+function Plugin:GUI_SetText( team, name, text, ... )
+	local myObj = self:GUI_GetObj( team, name )
+	if not SGUI.IsValid(myObj) then
+		self.Logger:Trace("Plugin:GUI:SetText object invalid.") 
+		return 
+	end
+	if not myObj.SetText then return end
+	if not ... then
+		myObj:SetText(text)
+		self.Logger:Trace("Plugin:GUI:SetText text %s", text)
+	else	
+		myObj:SetText(StringFormat(text, ...))
+		self.Logger:Trace("Plugin:GUI:SetText StringFormat %s", text)
+	end
+end
+
+
+function Plugin:NetworkUpdate( Key, Old, New )
+	self.Logger:Trace( "NetworkUpdate %s %s %s", Key, Old, New )
+
+	if Key == "Team1Name" then
+		self.TeamNames[1] = self.dt.Team1Name
+	elseif Key == "Team2Name" then
+		self.TeamNames[2] = self.dt.Team2Name
+	elseif Key == "CaptainTurn" then
+		self:UpdateTurn()
+	end
+end
+
+function Plugin:OnPickPlayer(PickID)
+	self.Logger:Debug( "Plugin:OnPickPlayer %s",PickID  ) 
+	self:SendNetworkMessage("PickPlayer", {pickid = PickID}, true)
+end
+
+function Plugin:OnTradePlayer(PickID)
+	self.Logger:Debug( "Plugin:OnTradePlayer %s",PickID  ) 
+	self:SendNetworkMessage("TradePlayer", {pickid = PickID}, true)
+end
+
+
+function Plugin:Cleanup()
+	self.Logger:Debug( "Plugin:Cleanup" ) 
+	self:SetTeamNames( )
+	self:CaptainMenuCleanup()
+	self.BaseClass.Cleanup(self)
+	
+end
+
+function Plugin:CaptainMenuCleanup()
+	self.Logger:Trace( "CaptainMenuCleanup" ) 
+	if not SGUI.IsValid( self.Window ) then
+	 	if self.Visible then
+			SGUI:EnableMouse(false, self.Window)
+		end
+		return 
+	end
+	self.Logger:Debug( "CaptainMenuCleanup Destroy Window" )
+	-- Hide and destroy the window	
+	self.Window:SetIsVisible(false)
+	SGUI:EnableMouse(false,self.Window) 
+	self.IgnoreRemove = true
+	self.Window:Destroy()
+	self.IgnoreRemove = nil
+	self.Window = nil
+
+	-- nil out all the SGUI items we are tracking
+	self.myGUIObjs = nil	
+	self.PickListSort = nil
+	self.PickList = nil
+	self.PickListSort = nil
+	self.PickList = nil
+	self.PickRows = nil 		
+	self.TeamList = nil
+	self.TeamListSort = nil
+	self.TeamListRows= nil
+	self.TeamTitles = nil
+	self.myTeamInput = nil
+	
+end
+
+
+function Plugin:ReceiveStartCaptains(Data)
+	self.Logger:Debug( "ReceiveStartCaptains" )
+	
+	self.InProgress = true
+
+	self.Team1IsMarines = Data.team1marines
+
+	if self.Team1IsMarines then
+		self.TeamStrings = {"Marines", "Aliens"}
+		self.TeamIndex = {1, 2}
+	else
+		self.TeamStrings = {"Aliens", "Marines"}
+		self.TeamIndex = {2, 1}
+	end	
+	
+	self.TeamNames[1] = self.dt.Team1Name
+	self.TeamNames[2] = self.dt.Team2Name
+
+
+	if SGUI.IsValid( self.Window ) then
+		self.Logger:Debug( "ReceiveStartCaptains: Force New CaptainMenu" ) 
+		self.IgnoreRemove = true
+		self.Window:Destroy()
+		self.IgnoreRemove = nil
+	end
+
+	self:SetIsVisible(true)
+	--[[self:CaptainMenuInitialise()
+	self.Window:SetIsVisible( true )
+	self.Window:InvalidateLayout( true )
+	SGUI:EnableMouse(true,self.Window)]]	
+	
+	StartSoundEffect("sound/NS2.fev/marine/voiceovers/commander/online", 3)
+	
+end
+
+
+function Plugin:ReceiveCaptainsMatchStart(Data)
+	self.Logger:Debug( "ReceiveCaptainsMatchStart" )
+	-- when the match starts.. remove stuff.
+	
+	self:SetIsVisible(false)
+	-- Having issues with Hidden objects and OnLoseFocus 
+	-- Try Destroy. 
+	
+	self.IgnoreRemove = true 
+	self.Window:Destroy()
+	self.IgnoreRemove = nil
+	self:CaptainMenuReset()
+	
+	self.MatchStart = true
+
+end
+
+
+function Plugin:ReceiveCaptainsMatchComplete(Data)
+	self.Logger:Debug( "ReceiveCaptainsMatchComplete" )
+	self:ResetState()
+	
+	if SGUI.IsValid( self.Window ) then
+		Plugin:CaptainMenuCleanup() 
+	end
+	
+end
+
+function Plugin:ReceiveEndCaptains(Data)
+	self.Logger:Debug( "ReceiveEndCaptains" )
+	self:ResetState()
+	
+	if SGUI.IsValid( self.Window ) then
+		self:CaptainMenuCleanup()
+		
+		StartSoundEffect("sound/NS2.fev/marine/voiceovers/commander/commander_ejected")
+	end
+	
+end
+
 
 function Plugin:ReceivePlayerStatus(Data)
 	-- Upsert player to local table
 	local Exists = false
-	for Index, Player in ipairs(Players) do
-		if Player.steamid == Data.steamid then
-			Players[Index] = Data
+	
+	local function GetTeamsAvgSkill(skill, skillOffset)
+  		return Max(0, skill + skillOffset), Max(0, skill - skillOffset); -- Marine, Alien
+	end
+	local function BuildSkillText(skill, marineSkill, alienSkill)
+		if skill == -1 then return nil end
+		local description                = StringFormat("Skill: %i", skill) 
+		if marineSkill ~= alienSkill then
+		    description = description .. StringFormat("\nMarine: %i", marineSkill)
+			description = description .. StringFormat("\nAlien: %i", alienSkill)
+		end
+	    return description      
+	end
+
+	
+	self.Logger:Debug( "ReceivePlayerStatus  %s {%s %s %s %s %s %s} "
+			, Data.name
+			, Data.pickid
+			, Data.steamid
+			, Data.team
+			, Data.pick
+			, Data.isCaptain
+			, Data.isPickable 
+			);
+			
+	-- Check if My StreamID is a captain.
+	local SteamID = Client.GetSteamId()
+	-- record which team captain the Client is.
+	if SteamID == tonumber(Data.steamid)
+	and Data.isCaptain == true 
+	then
+		self.myTeam = tonumber(Data.pick)
+		self.myPickid = Data.pickid
+	end	
+	
+	if Data.isCaptain and Data.pick > 0 then
+		self.CaptainNames[Data.pick] = Data.name	
+	end
+	
+	Data.marine, Data.alien = GetTeamsAvgSkill( Data.skill, Data.skilloffset )
+	-- Format Skill tooltip
+	Data.skillText = BuildSkillText( Data.skill, Data.marine, Data.alien)
+	
+	for Index, Player in ipairs(self.Players) do
+		if Player.pickid == Data.pickid then
+			if Player.pick > 0 and Player.pick ~= Data.pick then
+			-- pick change detected	
+				self.PickChange = true
+				if Player.isPickable ~= Data.isPickable then
+					self.SoldierLost = true
+				end 
+			end
+ 
+			self.Players[Index] = Data
 			Exists = true
 		end
 	end
 	if not Exists then
-		table.insert(Players, Data)
+		table.insert(self.Players, Data)
+	end
+	-- Process Updates in Think so we can queue up a few before we run through them.
+	self.QueuePlayerUpdate = true
+	
+end
+
+function Plugin:OnFirstThink()
+	self:CallModuleEvent("OnFirstThink")
+	self.Delay = 0.5
+	self.LastRun = Shared.GetTime()
+	self.NextRun = self.LastRun+ self.Delay
+	
+	self.ProcessUnsetReady = false
+	self.QueuePlayerUpdate = false
+	self.SoldierLost = false
+	
+	-- Hook into the scoreboard so we know when to hide	
+	Shine.Hook.SetupClassHook( "GUIScoreboard", "SendKeyEvent", "Captain_GUIScoreboardSendKeyEvent", "PassivePost")
+	
+end
+
+function Plugin:Think( DeltaTime )
+	local Time = Shared.GetTime()
+	if self.NextRun > Time then
+		return
+	end
+	self.LastRun = Time
+	self.NextRun = self.LastRun+ self.Delay
+	
+	if (self.ProcessUnsetReady ) then
+		self.ProcessUnsetReady = false
+		self:OnUnsetReady()
+	end
+	
+
+	if (self.QueuePlayerUpdate == true ) then
+		self.QueuePlayerUpdate = false
+		self:UpdatePlayers()
+	end
+	
+	if (self.SoldierLost) then
+		self.SoldierLost = false
+		StartSoundEffect("sound/NS2.fev/marine/voiceovers/soldier_lost", 5)
+	end 
+	
+end
+
+function Plugin:Captain_GUIScoreboardSendKeyEvent(  Scoreboard, Key, Down )
+-- This will run on Every keypress.
+	
+	-- if GameStarted then return end
+	if self.MatchStart then return end
+	
+	self.Scoreboard_IsVisible = self.Scoreboard_IsVisible or false 
+	self.Scoreboard_Captain = self.Scoreboard_Captain or false 
+
+	if not SGUI.IsValid( self.Window ) then
+		return 
 	end
 
-	self:UpdateCaptainMenu()
+	if Scoreboard.visible and not self.Scoreboard_IsVisible then
+		self.Scoreboard_IsVisible = true
+		self.Scoreboard_Captain = self.Window:GetIsVisible()
+		if not self.Scoreboard_Captain then
+			return
+		end
+		-- Hide captains menu
+		self.Window:SetIsVisible(false)
+		SGUI:EnableMouse(false,self.Window)
+		--self:FadeOut()
+		self.Logger:Trace( "Hide Captains menu Showing Scoreboard")
+		 
+	elseif not Scoreboard.visible and self.Scoreboard_IsVisible then
+		self.Scoreboard_IsVisible = false
+		if self.Scoreboard_Captain then
+			-- Unhide Captains Menu
+			self.Window:SetIsVisible( true )
+			SGUI:EnableMouse( true, self.Window )
+			--self:FadeIn()
+			self.Logger:Trace( "Unhide Captains menu Post Scoreboard") 
+		end
+		return
+	end
+
 end
 
-function Plugin:UpdateCaptainMenu(Data)
-	-- Rerun the init function to update the view with the new data.
-	-- Probably hacky
-	CaptainMenu.Window.ContentPanel:Clear()
-	CaptainMenu.Window.Tabs[CaptainMenu.Window.ActiveTab].OnPopulate(CaptainMenu.Window.ContentPanel)
+function Plugin:FadeIn()
+
+	if not SGUI.IsValid( self.Window ) then
+		return 
+	end
+
+	SGUI:EnableMouse( true, self.Window )
+
+	self.Window:SetIsVisible( true )
+	self.Window:ApplyTransition( {
+		Type = "Alpha",
+		StartValue = 0,
+		EndValue = 1,
+		Duration = 0.3
+	} )
+
 end
 
-function Plugin:ResetState()
-	Players = {}
-	TeamNames = {"Marines", "Aliens"}
-	IsReady = false
-	MyTurn = false
+local function OnFadeOutComplete( self )
+	-- self is Plugin.Window
+	self:SetIsVisible( false )
+	--SGUI:EnableMouse(true,self.Window)
 end
 
-function Plugin:ReceiveStartCaptains(Data)
-	Team1IsMarines = Data.team1marines
-	CaptainMenu.Window:SetIsVisible(true)
-	SGUI:EnableMouse(true)
+function Plugin:FadeOut( )
+
+	if not SGUI.IsValid( self.Window ) then
+		return 
+	end
+
+	self.Window:ApplyTransition( {
+		Type = "Alpha",
+		EndValue = 0,
+		Duration = 0.3,
+		Callback = OnFadeOutComplete
+	} )
 end
 
-function Plugin:ReceiveEndCaptains(Data)
-	Plugin:ResetState()
-	CaptainMenu.Window:SetIsVisible(false)
-	SGUI:EnableMouse(false)
-end
 
-function Plugin:ReceiveCaptainTurn(Data)
-	MyTurn = Data.turn
-	self:UpdateCaptainMenu()
-end
+
+
+
 
 function Plugin:ReceivePickNotification(Data)
 	Client.WindowNeedsAttention()
 
 	StartSoundEffect("sound/NS2.fev/common/ping")
-	-- StartSoundEffect("sound/NS2.fev/common/tooltip_off")
 
 	Shine.ScreenText.Add(
 		"PickNotification",
@@ -378,7 +1309,26 @@ function Plugin:ReceiveCountdownNotification(Data)
 	)
 end
 
+
+function Plugin:SetTeamNames( MarineName, AlienName )
+	if MarineName == nil 
+	or AlienName == nil then
+		Shared.ConsoleCommand( "teams \"reset\"" )
+		return
+	end 
+	
+	if MarineName == "" and AlienName == "" then return end
+
+	Shared.ConsoleCommand( StringFormat( "teams \"%s\" \"%s\"", MarineName, AlienName ) )
+	
+	self.Logger:Debug( "Captains Mode Team1 [%s] Team2 [%s]" , MarineName, AlienName)
+	
+end
+
 function Plugin:ReceiveTeamNamesNotification(Data)
+
+	self:SetTeamNames(Data.marines,Data.aliens)
+
 	Shine.ScreenText.Add(
 		"MarinesTeamName",
 		{
@@ -426,13 +1376,5 @@ function Plugin:ReceiveTeamNamesNotification(Data)
 	)
 end
 
-function Plugin:ReceiveTeamName(Data)
-	TeamNames[Data.team] = Data.teamname
-	self:UpdateCaptainMenu()
-end
 
-function Plugin:Cleanup()
-	self.BaseClass.Cleanup(self)
-
-	CaptainMenu.Window:Destroy()
-end
+Shine.LoadPluginModule( "logger.lua", Plugin )

--- a/lua/shine/extensions/captainsmode/server.lua
+++ b/lua/shine/extensions/captainsmode/server.lua
@@ -1,421 +1,1270 @@
-local Plugin = Plugin
+--[[
+	Captains Mode server.
+]]
+
+local Plugin = ...
+
 local Shine = Shine
+local ChatName = "Captains Mode"
+
+
+local TableSort = table.sort
+local TableCopy = table.Copy
+local TableConcat = table.concat
+local StringFormat = string.format
+local tostring = tostring
+
+
+Plugin.Conflicts = {
+	DisableThem = {
+		"voterandom"
+	}
+}
+
+
+-- Block these votes when Captains Mode is running.
+Plugin.BlockedEndOfMapVotes = {
+	--VoteResetGame = true,
+	VoteRandomizeRR = true,
+	VotingForceEvenTeams = true,
+	VoteChangeMap = true,
+	VoteAddCommanderBots = true
+}
+
+function Plugin:NS2StartVote( VoteName, Client, Data )
+	self.Logger:Debug( "Captains Mode NS2StartVote=========================== %s", VoteName)
+	if not (self.InProgress or self.GameStarted) then return end
+	--if not self:IsEndVote() and not self.CyclingMap then return end
+
+	if self.BlockedEndOfMapVotes[ VoteName ] then
+		self.Logger:Debug( "Captains Mode NS2StartVote=========================== **BLOCKED**")
+		return false, kVoteCannotStartReason.Waiting
+	end
+end
+
+
 
 function Plugin:Notify(Message, Color)
-    local ChatName = "Captains Mode"
-    local R, G, B = 255, 255, 255
-    if Color == "red" then
-        R, G, B = 255, 0, 0
-    elseif Color == "yellow" then
-        R, G, B = 255, 183, 2
-    elseif Color == "green" then
-        R, G, B = 79, 232, 9
-    end
+	local ChatName = "Captains Mode"
+	local R, G, B = 255, 255, 255
+	if Color == "red" then
+		R, G, B = 255, 0, 0
+	elseif Color == "yellow" then
+		R, G, B = 255, 183, 2
+	elseif Color == "green" then
+		R, G, B = 79, 232, 9
+	end
 
-    Shine:NotifyDualColour(nil, 131, 0, 255, ChatName .. ": ", R, G, B, Message)
+	Shine:NotifyDualColour(nil, 131, 0, 255, ChatName .. ": ", R, G, B, Message)
 end
 
 function Plugin:CreateCommands()
-    local function Captain(Client)
-        local Player = Client:GetControllingPlayer()
-        local PlayerName = Player:GetName()
 
-        -- If there is a game in progress, deny it.
-        local Gamerules = GetGamerules()
-        if Gamerules:GetGameStarted() then
-            Shine:Notify(Client, ChatName, PlayerName, "A game has already started.")
-            return
-        end
+	local function Captain(Client)
+		local PlayerName = Shine.GetClientName( Client )	
+		local Player       = Client:GetControllingPlayer()
+		local TeamNumber   = Player:GetTeamNumber()
+		if TeamNumber == 3 then
+			Shine:Notify(Client, ChatName, PlayerName, "Spectators not allowed to Captain.")
+			return
+		end
 
-        -- Check if the player is already a captain.
+		-- If there is a game in progress, deny it.
+		local Gamerules = GetGamerules()
+		if Gamerules:GetGameStarted() then
+			Shine:Notify(Client, ChatName, PlayerName, "A game has already started.")
+			return
+		end
+		-- Check if the player is already a captain.
         if self:GetCaptainIndex(Client) then
             Shine:Notify(Client, ChatName, PlayerName, "You are already a captain.")
+            if self.InProgress then
+            -- show the screen just in case. 
+            	self:SendNetworkMessage(Client, "ShowTeamMenu", {}, true)
+        	end
             return
         end
+		if #self.Captains < 2 then
+			table.insert(self.Captains, Client)
+			self:Notify(PlayerName .. " is now a captain.", "green")
+		else
+			Shine:Notify(Client, ChatName, PlayerName, "There are already 2 captains.")
+			return
+		end
 
-        if #self.Captains < 2 then
-            table.insert(self.Captains, Client)
-            self:Notify(PlayerName .. " is now a captain.", "green")
-        else
-            Shine:Notify(Client, ChatName, PlayerName, "There are already 2 captains.")
-            return
-        end
+		-- If this is the second captain, we start the pick process.
+		if #self.Captains > 1 then
+			self:StartCaptainsPresetup()
+			self:StartCaptains()
+			-- Cancel the adverts
+			self:DestroyTimer("NeedOneMoreCaptain")
+			return
+		end
 
-        -- If this is the second captain, we start the pick process.
-        if #self.Captains > 1 then
-            self:StartCaptains()
+		-- If we have only one captain, notify everyone that we need one more.
+		if #self.Captains == 1 then
+			self:Notify("Diamond Gamers Captains mode:")
+			self:Notify("To appoint yourself as captain, type !captain")
+			-- name, delay, reps, func
+			self:CreateTimer(
+				"NeedOneMoreCaptain",
+				20,
+				-1,
+				function(Timer)
+					local CaptainName = Shine.GetClientName( self.Captains[1] )
+					self:Notify("Need one more captain to start picking players.", "yellow")
+					self:Notify("To appoint yourself as captain, type !captain")
+					self:Notify(string.format("Current captain: %s", CaptainName))
+				end
+			)
+		end
+	end
 
-            -- Cancel the adverts
-            Shine.Timer.Destroy("NeedOneMoreCaptain")
+	local CaptainCommand = self:BindCommand("sh_cm_captain", "captain", Captain, true)
+	CaptainCommand:Help("Diamond Gamers Captains mode: Make yourself a captain.")
 
-            return
-        end
+	--[[
+		The sh_cm_cancel allows admins to cancel captains for the users.
+	]]
+	local function Cancel(Client)
+		local PlayerName = Shine.GetClientName( Client )
+		self:EndCaptains()
+		self:Notify(string.format("Captains mode was cancelled by %s.", PlayerName), "red")
+	end
+	local CaptainCommand = self:BindCommand("sh_cm_cancel", "cancelcaptains", Cancel)
+	CaptainCommand:Help("Cancel captains mode.")
+	
+	
+	
+	Shine:RegisterCommand( "sh_cm_list", nil, function (Client)
+		self:ReportTeams( Client )
+	end):Help( "Lists the current teams." )
+	
+	
+	
+	Shine:RegisterCommand( "sh_cm_teams", "showteams", function (Client)
+		if not self.InProgress then return end
+		if not Plugin.Config.AllowPlayersToViewTeams then return end 
+		self:SendNetworkMessage(Client, "ShowTeamMenu", {}, true)
+	end 
+	, true ):Help( "Show current Captain Teams." )
 
-        -- If we have only one captain, notify everyone that we need one more.
-        if #self.Captains == 1 then
-            self.Notify("Diamond Gamers Captains mode:")
-            self:Notify("To appoint yourself as captain, type !captain")
-            Shine.Timer.Create(
-                "NeedOneMoreCaptain",
-                20,
-                -1,
-                function(Timer)
-                    local CaptainName = self.Captains[1]:GetControllingPlayer():GetName()
-                    self:Notify("Need one more captain to start picking players.", "yellow")
-                    self:Notify("To appoint yourself as captain, type !captain")
-                    self:Notify(string.format("Current captain: %s", CaptainName))
-                end
-            )
-        end
-    end
 
-    local CaptainCommand = self:BindCommand("sh_cm_captain", "captain", Captain, true)
-    CaptainCommand:Help("Diamond Gamers Captains mode: Make yourself a captain.")
-
-    local function Cancel(Client)
-        local Player = Client:GetControllingPlayer()
-        local PlayerName = Player and Player:GetName() or "Console"
-        self:EndCaptains()
-        self:Notify(string.format("Captains mode was cancelled by %s.", PlayerName), "red")
-    end
-    local CaptainCommand = self:BindCommand("sh_cm_cancel", "cancelcaptains", Cancel)
-    CaptainCommand:Help("Cancel captains mode.")
+	Shine:RegisterCommand( "sh_cm_hidemouse", "hidemouse", function (Client)
+		self:SendNetworkMessage(Client, "HideMouse", {}, true)
+	end 
+	, true ):Help( "Hide the mouse if for some reason it is still showing." )		
+		
+	if Plugin.Config.AllowTesting then
+		self:CreateTestingCommands()
+	end
+			
 end
 
-function Plugin:Initialise()
-    self:ResetState()
-    self:CreateCommands()
+function Plugin:ReportTeams( Client )
+		
+	local SortTable = {}
+	local Count = 0
 
-    return true
+	for pickid, Player in pairs(self.Players) do
+		Count = Count + 1
+		SortTable[ Count ] = { pickid, Player }
+	end
+
+	TableSort( SortTable, function( A, B )
+		if A[ 2 ].pick < B[ 2 ].pick then return true
+		elseif A[ 2 ].pick > B[ 2 ].pick then return false 
+		end
+		if A[ 1 ] < B[ 1 ] then return true end
+		return false
+	end )
+
+	local Columns = {
+		{
+			Name = "Key",
+			Getter = function( Entry )
+				return StringFormat( "%s", Entry[1] )
+			end
+		},
+		{
+			Name = "ID",
+			Getter = function( Entry )
+				return StringFormat( "%s", Entry[2].pickid )
+			end
+		},				
+		{
+			Name = "Name",
+			Getter = function( Entry )
+				return tostring( Entry[2].name )
+			end
+		},
+		{
+			Name = "Steam ID",
+			Getter = function( Entry )
+				return tostring( Entry[2].steamid )
+			end
+		},			
+		{
+			Name = "Team",
+			Getter = function( Entry )
+				local teamNumber = Entry[2].team
+				return Plugin:GetTeamName( teamNumber or 5, true )
+			end
+		},
+		{
+			Name = "Picked",
+			Getter = function( Entry )
+				return tostring( Entry[2].pick )
+			end
+		},
+		{
+			Name = "Skill",
+			Getter = function( Entry )
+				return tostring( Entry[2].skill )
+			end
+		}
+	}
+	Shine.PrintTableToConsole( Client, Columns, SortTable )
+
+end
+
+
+function Plugin:Initialise()
+	self:BroadcastModuleEvent( "Initialise" )
+	self.Logger:Debug( "Server Initialise" )
+
+	self:ResetState()
+	self:CreateCommands()
+	
+	self:TestingCaptainsInitialise()
+
+	return true
 end
 
 function Plugin:ResetState()
-    self.Captains = {}
-    self.TeamNames = {"Marines", "Aliens"}
-    self.Ready = {false, false}
+	
+	self.Logger:Debug( "Server ResetState" )
+	self:DestroyAllTimers()
+	self.InProgress = false
 
-    self.CaptainFirstTurn = nil
-    self.CaptainTurn = nil
-    self.InProgress = false
-    self.Players = {}
+	self.Players = {}
+	self.Captains = {}
+	
+	self.TeamNames = {"Marines", "Aliens"}
+	self.Ready = {false, false}
+	self.LastCount = {0,0}
 
-    if math.random(0, 1) == 1 then
-        self.Team1IsMarines = true
-    else
-        self.Team1IsMarines = false
-    end
-
-    Shine.Timer.Destroy("NeedOneMoreCaptain")
+	self.CaptainFirstTurn = nil
+	self.CaptainTurn = nil
+	self.MovingPlayers = false
+	self.GameStarted = false
+	
+	if math.random(0, 1) == 1 then
+		self.Team1IsMarines = true
+		self.dt.Team1Name= self.TeamNames[1]
+		self.dt.Team2Name= self.TeamNames[2]
+	else
+		self.Team1IsMarines = false
+		self.dt.Team1Name= self.TeamNames[2]
+		self.dt.Team2Name= self.TeamNames[1]
+	end
+	self.dt.CaptainTurn = 0
+	
 end
 
 function Plugin:GetCaptainIndex(Client)
-    local CaptainIndex = nil
-    for Index, CaptainClient in pairs(self.Captains) do
-        if CaptainClient == Client then
-            CaptainIndex = Index
-        end
-    end
-    return CaptainIndex
+	self.Logger:Trace( "Server GetCaptainIndex" )
+	local CaptainIndex = nil
+	if Client == nil then return CaptainIndex end
+	
+	for Index, CaptainClient in pairs(self.Captains) do
+		if CaptainClient == Client then
+			CaptainIndex = Index
+			-- Return when we found it.
+			return CaptainIndex
+		end
+	end
+	return CaptainIndex
 end
 
+
+function Plugin:GetPickId(Client)
+	
+	local SteamID = Client:GetUserId()
+	local ClientID = Client:GetId()
+	local ID 
+	if SteamID > 0 then
+		ID = tostring(SteamID)
+	else
+		ID = StringFormat("BOT%s",ClientID)
+	end
+	return ID
+		
+end
+--[[
+	Processing a player change to the clients 
+]]
+function Plugin:PlayerUpdate( Client )
+	
+	if not self.InProgress then return end
+	
+	local Player       = Client:GetControllingPlayer()
+	local SteamID      = Client:GetUserId()
+	--local ClientID     = Client:GetId()
+	--local PlayerID     = Player:GetId()
+	local PlayerName   = Player:GetName()
+	local Skill        = Player:GetPlayerSkill()
+	local SkillOffset  = Player:GetPlayerSkillOffset()
+	local TeamNumber   = Player:GetTeamNumber()
+	local CaptainIndex = self:GetCaptainIndex( Client ) or 0
+	local pickid       = self:GetPickId(Client)
+
+	local Data = {
+			Client = Client,
+			
+			pickid = pickid,
+			steamid = SteamID, 
+			name = PlayerName, 
+			skill = Skill,
+			skilloffset = SkillOffset, 
+			team = TeamNumber, 
+			pick = CaptainIndex, 
+			isPickable  = not (TeamNumber == 3 or TeamNumber > 4),
+			isCaptain = not (CaptainIndex == 0 )  
+		}
+	self.Logger:Debug( "Server Player Update (%s) %s [%s]", Data.steamid, Data.name , Data.pick )
+
+	local oldData = self.Players[pickid]
+	if (oldData ~= nil and oldData.steamid == Data.steamid) then
+		-- keep the current pick, update everything else.
+		Data.pick = oldData.pick
+		self.Players[pickid] = Data
+		self:PlayerStatus( Data )
+		--oldData.Client = Data.Client
+		--oldData.name = Data.name
+		--oldData.team = Data.team
+		--oldData.isPickable = Data.isPickable
+		--self:PlayerStatus( oldData )
+	else
+		self.Players[pickid] = Data
+		self:PlayerStatus( Data )
+	end
+		
+end
+--[[
+	Send Player Status to clients  
+]]
+function Plugin:PlayerStatus( PlayerStatus )
+	-- PlayerStatus = self.Players[pickid]
+	
+	if not self.InProgress then return end
+
+	if Plugin.Config.AllowPlayersToViewTeams then
+		self:SendNetworkMessage(nil, "PlayerStatus", PlayerStatus, true)
+	else
+		self:SendNetworkMessage(self.Captains, "PlayerStatus", PlayerStatus, true)
+	end
+end
+
+--[[
+	StartCaptainsPresetup : these are things we want done to prepare the game for Captains.
+]]
+function Plugin:StartCaptainsPresetup()
+
+	self.Logger:Debug( "Server Start Captains Presetup" )
+	self.InProgress = true
+
+	if Plugin.Config.AutoRemoveBots then
+		Shared.ConsoleCommand(string.format("sv_maxbots %d", 0))
+	end
+	if Plugin.Config.AutoDisableVoteRandom then
+		--[[
+			trying instead of this. Plugin.Conflicts.DisableThem
+			This didn't really work anyway
+		]]
+		-- diable the plugin that auto random teams at start.?
+		-- no : Shared.ConsoleCommand("sh_disableplugin voteRandom")
+		-- yes: Shared.ConsoleCommand("sh_unloadplugin voteRandom")
+	end
+	if Plugin.Config.AutoReadyRoom then
+		--this forces everyone to the ready room
+		--Shared.ConsoleCommand("sh_rr *")
+		--Shine.mapvote:ForcePlayersIntoReadyRoom()
+		local MapVote= Shine.Plugins.mapvote
+		if MapVote and MapVote.Enabled then
+			MapVote:ForcePlayersIntoReadyRoom()
+		else
+			-- fallback to just moving *everyone* to the readyroom.
+			Shared.ConsoleCommand("sh_rr *")
+		end
+	end
+end
+--[[
+	StartCaptains: Start by sending all the players to the clients and setting who picks first.
+]]
 function Plugin:StartCaptains()
-    local GameIDs = Shine.GameIDs
+	local GameIDs = Shine.GameIDs
+	self.Logger:Debug( "Server Start Captains" )
 
-    if Plugin.Config.AutoRemoveBots then
-        Shared.ConsoleCommand(string.format("sv_maxbots %d", 0))
-    end
-    if Plugin.Config.AutoDisableVoteRandom then
-        Shared.ConsoleCommand("sh_unloadplugin voterandom")
-    end
-    if Plugin.Config.AutoReadyRoom then
-        Shared.ConsoleCommand("sh_rr *")
-    end
+	self:Notify("Captains mode has started!", "yellow")
 
-    self.InProgress = true
-    self:Notify("Captains mode has started!", "yellow")
+	local Captain1Name = Shine.GetClientName( self.Captains[1] )
+	local Captain2Name = Shine.GetClientName( self.Captains[2] ) 
+	self:Notify(string.format("Please wait while %s and %s pick teams.", Captain1Name, Captain2Name))
 
-    local Captain1Name = self.Captains[1]:GetControllingPlayer():GetName()
-    local Captain2Name = self.Captains[2]:GetControllingPlayer():GetName()
-    self:Notify(string.format("Please wait while %s and %s pick teams.", Captain1Name, Captain2Name))
+	-- Send Player:client to  everyone
+	self.Logger:Debug( "Server Start Captains : Send Players" )  
+	for Client, ID in GameIDs:Iterate() do
+		self:PlayerUpdate( Client )
+	end
 
-    for Client, ID in GameIDs:Iterate() do
-        local SteamID = Client:GetUserId()
-        local Player = Client:GetControllingPlayer()
-        local PlayerName = Player:GetName()
+	
+	if Plugin.Config.AllowPlayersToViewTeams then
+		self:SendNetworkMessage( nil , "StartCaptains", {team1marines = self.Team1IsMarines}, true)
+	else
+		self:SendNetworkMessage(self.Captains, "StartCaptains", {team1marines = self.Team1IsMarines}, true)
+	end
 
-        -- TeamNumber is used for the captain's picking process. See shared.lua
-        -- Make spectators not available for picking.
-        local TeamNumber
-        if Player:GetTeamNumber() ~= 3 then
-            TeamNumber = 3
-        else
-            TeamNumber = 0
-        end
+	local Cap1Skill = self.Captains[1]:GetControllingPlayer():GetPlayerSkill()
+	local Cap2Skill = self.Captains[2]:GetControllingPlayer():GetPlayerSkill()
+	local Cap1_ID = self.Captains[1]:GetUserId()
+	local Cap2_ID = self.Captains[2]:GetUserId()
 
-        local CaptainIndex = self:GetCaptainIndex(Client)
-        if CaptainIndex then
-            TeamNumber = CaptainIndex
-        end
-
-        local Skill = Player:GetPlayerSkill()
-        local Data = {steamid = SteamID, name = PlayerName, skill = Skill, team = TeamNumber}
-        self:Notify(Data)
-        self.Players[SteamID] = Data
-        self:SendNetworkMessage(self.Captains, "PlayerStatus", Data, true)
-    end
-
-    self:SendNetworkMessage(self.Captains, "StartCaptains", {team1marines = self.Team1IsMarines}, true)
-
-    local Cap1Skill = self.Captains[1]:GetControllingPlayer():GetPlayerSkill()
-    local Cap2Skill = self.Captains[2]:GetControllingPlayer():GetPlayerSkill()
-
-    -- Decide who picks first based on hiveskill
-    if Cap1Skill > Cap2Skill then
-        self.CaptainTurn = self.Captains[2]
-        self.CaptainFirstTurn = 2
-        self:SendNetworkMessage(self.Captains[1], "CaptainTurn", {turn = false}, true)
-        self:SendNetworkMessage(self.Captains[2], "CaptainTurn", {turn = true}, true)
-    else
-        self.CaptainTurn = self.Captains[1]
-        self.CaptainFirstTurn = 1
-        self:SendNetworkMessage(self.Captains[1], "CaptainTurn", {turn = true}, true)
-        self:SendNetworkMessage(self.Captains[2], "CaptainTurn", {turn = false}, true)
-    end
-    local CaptainName = self.CaptainTurn:GetControllingPlayer():GetName()
-    self:Notify(CaptainName .. " picks first.", "green")
+	local CaptainTurnIndex
+	-- Decide who picks first based on hiveskill
+	if Cap1Skill > Cap2Skill then
+		CaptainTurnIndex = 2
+	else
+		CaptainTurnIndex = 1
+	end
+	self.CaptainTurn = self.Captains[CaptainTurnIndex]
+	self.CaptainFirstTurn = CaptainTurnIndex
+	-- Everyone gets notified when the self.dt.CaptainTurn changes.
+	self.dt.CaptainTurn = CaptainTurnIndex
+	
+	local CaptainName =  Shine.GetClientName( self.CaptainTurn ) 
+	self:Notify(CaptainName .. " picks first.", "green")
 end
+
 
 function Plugin:ReceiveSetTeamName(Client, Data)
-    local CaptainIndex = self:GetCaptainIndex(Client)
-    if CaptainIndex then
-        local TeamName = Data.teamname
-        self.TeamNames[CaptainIndex] = TeamName
-        self:SendNetworkMessage(self.Captains, "TeamName", {team = CaptainIndex, teamname = TeamName}, true)
-        Shared.ConsoleCommand(string.format("sh_setteamname %s %s", CaptainIndex, TeamName))
-    end
+	local CaptainIndex = self:GetCaptainIndex(Client)
+	self.Logger:Debug( "Server ReceiveSetTeamName " )
+	
+	if CaptainIndex then
+		local TeamName = Data.teamname
+		self.Logger:Debug( "Captain %s changed their team name %s", CaptainIndex, TeamName )		
+		self.TeamNames[CaptainIndex] = TeamName
+		if CaptainIndex == 1 then
+			self.dt.Team1Name = TeamName
+		elseif CaptainIndex == 2 then
+			self.dt.Team2Name = TeamName
+		else
+			return
+		end
+	end
 end
 
+function Plugin:SendUnsetReady()
+
+	for Index, CaptainClient in pairs(self.Captains) do
+		if self.Ready[Index] then
+			self.Ready[Index] = false
+			self:SendNetworkMessage(CaptainClient, "UnsetReady", {}, true)
+			if self:IsCaptainBot( Index ) then
+				-- just mark bots back as ready.
+				self.Ready[Index] = true
+			end 
+		end
+	end
+	
+end
+
+function Plugin:IsCaptainBot(CaptainIndex)
+	if self.TestingCaptainBots and self.TestingCaptainBots[CaptainIndex] ~= nil  then
+		return true
+	end
+	return false
+end
+
+
+
 function Plugin:ReceiveSetReady(Client, Data)
-    local Team = self:GetCaptainIndex(Client)
-    local Ready = Data.ready
-    local PlayerName = Client:GetControllingPlayer():GetName()
+	local Team = self:GetCaptainIndex(Client)
+	local Ready = Data.ready
+	local CaptainName = Shine.GetClientName( Client )
+	
+	self.Logger:Debug( "Server ReceiveSetReady " )
 
-    if Team then
-        self.Ready[Team] = Data.ready
-        if Ready then
-            self:Notify(PlayerName .. "'s team is ready.", "green")
-        else
-            self:Notify(PlayerName .. "'s team is not ready.", "red")
-        end
-    end
+	if Team then
+		self.Ready[Team] = Data.ready
+		if Ready then
+			self:Notify(CaptainName .. "'s team is ready.", "green")
+		else
+			self:Notify(CaptainName .. "'s team is not ready.", "red")
+		end
+	end
 
-    if self.Ready[1] and self.Ready[2] then
-        local Gamerules = GetGamerules()
+	
+	if self.Ready[1] and self.Ready[2] then
+		local revokePick = false
+		
+		local TeamCount = {0, 0}
+		
+		for pickid, Player in pairs(self.Players) do
+			if Player.isPickable then
+			-- Revoke Pickable if Client is no longer valid.
+				Player.isPickable = Shine:IsValidClient( Player.Client )
+				if not Player.isPickable then 
+					Player.team = 5
+					Player.Client = nil
+				end 
+			end
 
-        local Teams
-        if self.Team1IsMarines then
-            Teams = {1, 2}
-        else
-            Teams = {2, 1}
-        end
+			if not Player.isPickable and Player.pick ~= 0 then
+				-- revoke pick
+				self:Notify(string.format("Picked player %s removed from team %s[%s].", Player.name,  Shine.GetClientName( self.Captains[Player.pick] ),Player.pick), "red")
+				self.Logger:Debug( "Server ReceiveSetReady revoke pick %s", Player.name )
+				Player.pick = 0
+				self:PlayerStatus( Player )
+				revokePick = true
+				
+			end
+			if Player.isPickable and Player.pick ~= 0 then
+				if Player.pick == 1 then
+					TeamCount[1] = TeamCount[1] + 1
+				end
+				if Player.pick == 2 then
+					TeamCount[2] = TeamCount[2] + 1
+				end			
+			end 
+		end
+		
+		-- Make sure teams are not more than one appart.
+		if TeamCount[1] > (TeamCount[2]+1) 
+		or TeamCount[2] > (TeamCount[1]+1) then
+			if  self.LastCount[1] ~= TeamCount[1]
+			or self.LastCount[2] ~= TeamCount[2] then
+				self.LastCount[1] = TeamCount[1]
+				self.LastCount[2] = TeamCount[2]
+		  		-- Send back for Trades. PostTradeReady
+			  	self:Notify("Team count imbalance detected. Try to trade players to balance teams.", "red")
+				self:SendUnsetReady()
+				return
+			end
+			-- We told them they were off, but the ready'ed up anyway.
+		end
+		-- We had to remove a player. Let the captains know to review picks.
+		if revokePick then
+			self:Notify("Unavailable players removed. Ready Up again.", "red")
+			self:SendUnsetReady() 
+			return
+		end
+		self.LastCount[1] = TeamCount[1]
+		self.LastCount[2] = TeamCount[2]
+		
+		self:ReportTeams( nil )
+		
+		self:StartTeams()
+	end
+end
 
-        -- Start the game
-        for SteamID, Player in pairs(self.Players) do
-            if Player.team == 1 or Player.team == 2 then
-                local PlayerObj = Shine.GetClientByNS2ID(SteamID):GetControllingPlayer()
-                Gamerules:JoinTeam(PlayerObj, Teams[Player.team], true, true)
-            end
-        end
 
-        -- Just close the GUI for now but don't reset state
-        self:SendNetworkMessage(self.Captains, "EndCaptains", {}, true)
+function Plugin:StartTeams()		
 
-        self:StartGame()
-    end
+	local Gamerules = GetGamerules()
+	
+	local Teams
+	if self.Team1IsMarines then
+		Teams = {1, 2}
+	else
+		Teams = {2, 1}
+	end
+	
+	self.MovingPlayers = true
+
+	-- Start the game
+	for pickid, Player in pairs(self.Players) do
+		if Player.pick == 1 or Player.pick == 2 then
+			--local client = Shine.GetClientByNS2ID(SteamID)
+			local client = Player.Client
+			if client == nil then
+				-- added this because its required when using BOTS
+				client = Shine.GetClientByName(Player.name) 
+			end
+			
+			if Shine:IsValidClient( client ) then 
+				local PlayerObj = client and client:GetControllingPlayer()
+				if PlayerObj ~= nil then
+					Gamerules:JoinTeam(PlayerObj, Teams[Player.pick], true, true)
+				else
+					Shine:NotifyError(nil,string.format("Player %s not found", Player.name))
+				end
+			end
+		end
+	end
+	
+	self.MovingPlayers = false
+
+	-- Just close the GUI for now but don't reset state
+	self:SendNetworkMessage(nil, "CaptainsMatchStart", {}, true)
+
+	self:StartGame()
+
 end
 
 function Plugin:StartGame()
-    local Gamerules = GetGamerules()
-    local Seconds = Plugin.Config.CountdownSeconds
+	self.Logger:Debug( "Server StartGame " )
+	local Seconds = Plugin.Config.CountdownSeconds
 
-    Shine.Timer.Create(
-        "GameStartCountdown",
-        1,
-        Seconds,
-        function(Timer)
-            Seconds = Seconds - 1
-            self:SendNetworkMessage(
-                nil,
-                "CountdownNotification",
-                {text = string.format("Game will start in %s seconds", Seconds)},
-                true
-            )
-            if Seconds == 0 then
-                Gamerules:ResetGame()
-                Gamerules:SetGameState(kGameState.Countdown)
-                Gamerules.countdownTime = kCountDownLength
-                Gamerules.lastCountdownPlayed = nil
+	local function ForceRoundStart( )
+		local Gamerules = GetGamerules()
+		Gamerules:ResetGame()
+		Gamerules:SetGameState( kGameState.Countdown )
+		local Players = Shine.GetAllPlayers()
+		for i = 1, #Players do
+			local Player = Players[ i ]
+			if Player and Player.ResetScores then
+				Player:ResetScores()
+			end
+		end
+		Gamerules.countdownTime = kCountDownLength
+		Gamerules.lastCountdownPlayed = nil
+	end
+	
+	self:CreateTimer( 
+		"GameStartCountdown",
+		1,
+		Seconds,
+		function(Timer)
+			Seconds = Seconds - 1
+			
+			if (Seconds < 6 or (Seconds % 5) == 0) then
+			
+			self:SendNetworkMessage(
+				nil,
+				"CountdownNotification",
+				{text = string.format("Game will start in %s seconds", Seconds)},
+				true
+			)
+			
+			end
+			if Seconds == 0 then
+				self.Logger:Debug( "Server StartGame GameStartCountdown" )
+				ForceRoundStart()
+			end
+		end
+	)
 
-                local MarinesTeamName
-                local AliensTeamName
-                if self.Team1IsMarines then
-                    MarinesTeamName = self.TeamNames[1]
-                    AliensTeamName = self.TeamNames[2]
-                else
-                    MarinesTeamName = self.TeamNames[2]
-                    AliensTeamName = self.TeamNames[1]
-                end
-
-                self:SendNetworkMessage(
-                    nil,
-                    "TeamNamesNotification",
-                    {marines = MarinesTeamName, aliens = AliensTeamName},
-                    true
-                )
-            end
-        end
-    )
-
-    local Players, Count = Shine.GetAllPlayers()
-    for i = 1, Count do
-        local Player = Players[i]
-        if Player.ResetScores then
-            Player:ResetScores()
-        end
-    end
 end
 
+--[[
+	MatchComplete - for when you want to rest the state, but not end the mod.
+]]
+function Plugin:MatchComplete()
+	self.Logger:Debug( "Server MatchComplete" )
+	
+	self:SendNetworkMessage(nil, "CaptainsMatchComplete", {}, true)
+	self:ResetState()
+	--self:SendNetworkMessage(self.Captains, "EndCaptains", {}, true)
+
+end
+
+
 function Plugin:EndCaptains()
-    self:SendNetworkMessage(self.Captains, "EndCaptains", {}, true)
-    self:ResetState()
+	self.Logger:Debug( "Server EndCaptains" )
+	self:SendNetworkMessage( nil, "EndCaptains", {}, true)
+	self:ResetState()
  
-    if Plugin.Config.AutoRemoveBots then
-        Shared.ConsoleCommand(string.format("sv_maxbots %d", 12))
-    end
-    if Plugin.Config.AutoDisableVoteRandom then
-        Shared.ConsoleCommand("sh_loadplugin voterandom")
-    end
-    if Plugin.Config.AutoDisableSelf then
-        Shared.ConsoleCommand("sh_unloadplugin captainsmode")
-        self:Notify("Captains mode completed please ask a Diamond admin to reset the plugin.")
-    end
+	if Plugin.Config.AutoRemoveBots then
+		Shared.ConsoleCommand(string.format("sv_maxbots %d", 12))
+	end
+	if Plugin.Config.AutoDisableVoteRandom then
+	-- sh_loadplugin & sh_unloadplugin
+		Shared.ConsoleCommand("sh_enableplugin voteRandom")
+		--Shared.ConsoleCommand("sh_loadplugin voteRandom")
+	end
+	if Plugin.Config.AutoDisableSelf then
+		--Shared.ConsoleCommand("sh_disableplugin captainsmodeharq")
+		--Shared.ConsoleCommand("sh_unloadplugin captainsmodeharq")
+		--self:Notify("Captains mode completed please ask a Diamond admin to reset the plugin.")
+	end
 end
 
 function Plugin:ReceiveRequestEndCaptains(Client, Data)
-    if self:GetCaptainIndex(Client) then
-        local PlayerName = Client:GetControllingPlayer():GetName()
-        self:Notify("Captains mode was cancelled by " .. PlayerName .. ".", "yellow")
-        self:EndCaptains()
-    end
+	self.Logger:Debug( "Server ReceiveRequestEndCaptains" )
+	if self:GetCaptainIndex(Client) 
+	or Shine:HasAccess( Client, "sh_cm_cancel" ) 
+	then
+		local PlayerName = Shine.GetClientName( Client )
+		self:EndCaptains()
+		self:Notify("Captains mode was cancelled by " .. PlayerName .. ".", "yellow")
+	else
+		local PlayerName = Shine.GetClientName(Client)
+		Shine:Notify(Client, ChatName, PlayerName, "You are not allowed to end Captains.")
+	end
+
 end
 
 function Plugin:ReceivePickPlayer(Client, Data)
-    -- Check the client is a captain and it's his turn
-    local CaptainIndex = self:GetCaptainIndex(Client)
-    if not CaptainIndex or Client ~= self.CaptainTurn then
-        return
-    end
+	local CaptainName = Shine.GetClientName( Client )
+	self.Logger:Debug( "Server ReceivePickPlayer Client %s", CaptainName )
+	-- If we are not on a Captain Turn then don't process anything.	
+	if self.dt.CaptainTurn == 0 then return end
+	-- Check the client is a captain and it's his turn
+	local CaptainIndex = self:GetCaptainIndex(Client)
+	if not CaptainIndex then
+		self.Logger:Debug( "Received Player pick from an invalid player. %s is not a captain", CaptainName )
+		return
+	elseif Client ~= self.CaptainTurn then
+		self.Logger:Debug( "Received Player pick from wrong Captain. %s is not supposed to be picking.", CaptainName )
+		return
+	end
+	
+	-- we expect it to be this captains turn: 
+	currentPicker = self.Captains[self.dt.CaptainTurn]
+	if currentPicker ~= Client then
+		return
+	end
+ 
+	-- Update local players table
+	local Pick = self.Players and self.Players[Data.pickid]
+	if Pick and Pick.pick then
+		if Pick.pick ~= 0  then
+		-- Player was already picked.
+			self.Logger:Debug( "Received Player pick [%s] for team %s, but they are already on team %s.", Pick.name, CaptainName, Pick.pick  )
+			-- send invalid pick??
+	 		Shine:Notify(Client, ChatName, CaptainName, "Player you picked is already on the other team.")
+			self:SetCaptainTurn()
+			return
+		end
+		Pick.pick = self.dt.CaptainTurn
+		self:PlayerStatus( Pick )
+	else
+		self.Logger:Debug( "Received Player pick for ID [%s] but it was not found in Player list.", Data.pickid)
+		Shine:Notify(Client, ChatName, CaptainName, "Player you picked was not found in the Player list.")
+		self:SetCaptainTurn()
+		return
+	end
 
-    -- Update local players table
-    local Pick = self.Players[tonumber(Data.steamid)]
-    Pick.team = CaptainIndex
+	local PickMsg
+	if Plugin.Config.AnnouncePlayerNames then
+		PickMsg = CaptainName .. " picks " .. Pick.name .. "."
+	else
+		PickMsg = CaptainName .. " has picked a player."
+	end
+	self.Logger:Debug( "Captain %s picks %s.", CaptainName, Pick.name )
+	self:Notify(PickMsg)
+	self:SendNetworkMessage(nil, "PickNotification", {text = PickMsg}, true)
 
-    -- Send pick to captains
-    self:SendNetworkMessage(self.Captains, "PlayerStatus", Pick, true)
+	self:SetCaptainTurn()
 
-    local CaptainName = Client:GetControllingPlayer():GetName()
-    local PickMsg
-    if Plugin.Config.AnnouncePlayerNames then
-        PickMsg = CaptainName .. " picks " .. Pick.name .. "."
-    else
-        PickMsg = CaptainName .. " has picked a player."
-    end
-
-    self:Notify(PickMsg)
-    self:SendNetworkMessage(nil, "PickNotification", {text = PickMsg}, true)
-
-    -- Turn logic
-    local TeamCount = {0, 0}
-
-    for SteamID, Player in pairs(self.Players) do
-        if Player.team == 1 then
-            TeamCount[1] = TeamCount[1] + 1
-        end
-        if Player.team == 2 then
-            TeamCount[2] = TeamCount[2] + 1
-        end
-    end
-
-    local CaptainTurnIndex
-    if self.CaptainFirstTurn == 1 then
-        if TeamCount[1] > TeamCount[2] and CaptainIndex == 1 then
-            CaptainTurnIndex = 2
-        end
-        if TeamCount[2] >= TeamCount[1] and CaptainIndex == 2 then
-            CaptainTurnIndex = 1
-        end
-    else
-        if TeamCount[1] >= TeamCount[2] and CaptainIndex == 1 then
-            CaptainTurnIndex = 2
-        end
-        if TeamCount[2] > TeamCount[1] and CaptainIndex == 2 then
-            CaptainTurnIndex = 1
-        end
-    end
-    self.CaptainTurn = self.Captains[CaptainTurnIndex]
-
-    if CaptainTurnIndex == 1 then
-        self:SendNetworkMessage(self.Captains[2], "CaptainTurn", {turn = false}, true)
-        self:SendNetworkMessage(self.Captains[1], "CaptainTurn", {turn = true}, true)
-    else
-        self:SendNetworkMessage(self.Captains[2], "CaptainTurn", {turn = true}, true)
-        self:SendNetworkMessage(self.Captains[1], "CaptainTurn", {turn = false}, true)
-    end
 end
 
+function Plugin:ReceiveTradePlayer(Client, Data)
+	local CaptainName = Shine.GetClientName( Client )
+	self.Logger:Debug( "Server ReceiveTradePlayer Client %s", CaptainName )
+	local CaptainIndex = self:GetCaptainIndex(Client)
+	if not CaptainIndex then
+		self.Logger:Debug( "Received Player trade from an invalid player. %s is not a captain", CaptainName )
+		return
+	end
+
+	local OtherCaptain = (CaptainIndex % 2) + 1
+	-- Update local players table
+	local Pick = self.Players and self.Players[Data.pickid]
+	if Pick and Pick.isCaptain and Pick.Client and Pick.Client == Client then
+		self.Logger:Debug( "Received Player trade: Player %s tried to trade themselves.", CaptainName)
+		Shine:Notify(Client, ChatName, CaptainName, "You are not allowed to trade yourself.")
+		return
+	end
+	
+	if Pick and Pick.pick then
+		if Pick.pick == CaptainIndex then  
+			Pick.pick = (CaptainIndex % 2) + 1
+			self:SendUnsetReady()
+		 	-- Send Trade
+			self:PlayerStatus( Pick )
+		elseif self.IsCaptainBot and self:IsCaptainBot(OtherCaptain) then
+			Pick.pick =  (Pick.pick % 2) + 1
+			self:SendUnsetReady()
+		 	-- Send Trade
+			self:PlayerStatus( Pick )
+			
+		else
+			self.Logger:Debug( "Received Player trade for ID [%s] but it was not found on team %s.", Data.pickid,CaptainIndex)
+			Shine:Notify(Client, ChatName, CaptainName, "Player you traded was not found on your team.")
+			return
+		end		
+	else
+		self.Logger:Debug( "Received Player trade for ID [%s] but it was not found in Player list.", Data.pickid)
+		Shine:Notify(Client, ChatName, CaptainName, "Player you traded was not found in the Player list.")
+		return
+	end
+	-- Reset Last count on any trade
+	self.LastCount = {0,0}
+
+end
+
+
+
+function Plugin:SetCaptainTurn()
+
+	-- Turn logic
+	local TeamCount = {0, 0}
+
+	for pickid, Player in pairs(self.Players) do
+		if Player.pick == 1 then
+			TeamCount[1] = TeamCount[1] + 1
+		end
+		if Player.pick == 2 then
+			TeamCount[2] = TeamCount[2] + 1
+		end
+	end
+
+	--local CaptainTurnIndex
+	local CaptainTurnIndex = (self.dt.CaptainTurn % 2 ) + 1
+	-- Adjust turn for Team Count?
+	if self.CaptainFirstTurn == 1 and CaptainTurnIndex == 1 and TeamCount[1] > TeamCount[2] then
+		--allow 2 to pick again
+		CaptainTurnIndex = 2
+	elseif self.CaptainFirstTurn == 2 and CaptainTurnIndex == 2 and TeamCount[2] > TeamCount[1] then
+		--allow 1 to pick again
+		CaptainTurnIndex = 1
+	end
+	
+	self.CaptainTurn = self.Captains[CaptainTurnIndex]
+	self.dt.CaptainTurn = CaptainTurnIndex  
+
+end
+--[[
+	Block players from joining Marines or Aliens while we are Picking Teams
+]]
 function Plugin:JoinTeam(_, Player, NewTeam, Force, ShineForce)
-    if self.InProgress then
-        local SteamID = Player:GetClient():GetUserId()
+	if ShineForce then self.Logger:Trace( "Server JoinTeam Force"); return end
+	if not self.InProgress then return end
+	if not Player then return end
+	local PlayerName = Player:GetName()
+	
+	-- this is "before" the team on Player:GetTeamNumber is updated.
+	if NewTeam == 3 then
+		-- Don't allow captains into spec
+		local Client = Shine.GetClientForPlayer( Player )
+		local CaptainIndex = self:GetCaptainIndex(Client)
+		if CaptainIndex > 0 then
+			Shine:NotifyError(Player
+				,string.format("Captain not allowed to join %s [%s]. You must !cancelcaptains first."
+					, Plugin:GetTeamName( NewTeam )
+					, NewTeam)) 
+			return false 
+		end
+		--Moved To Spectate
+ 		--Shine:NotifyError(Player,string.format("Attempting to join Team %s", NewTeam))		
+		return
+	elseif NewTeam == 0 then
+		return		
+	else
+		-- If we are testing, Allow Allow Bots to join teams.
+		if self.TestingCaptains then 
+			local Client = Shine.GetClientForPlayer( Player )
+			if Client and Client:GetIsVirtual() then return end
+		end
+		-- Not Spectate, Not ReadyRoom
+		self.Logger:Debug( "Player Blocked from joining team %s : %s", NewTeam, PlayerName )
+		Shine:NotifyError(Player,string.format("Not allowed to join %s while captains picking is active.", Plugin:GetTeamName( NewTeam ) ))
+		return false
+	end
 
-        -- Toggle availability when joining or leaving spectator team
-        local TeamNumber
-        if NewTeam == 3 then
-            TeamNumber = 0
-        elseif self.Players[SteamID].team == 0 then
-            TeamNumber = 3
-        else
-            return
-        end
-
-        self.Players[SteamID].team = TeamNumber
-
-        self:SendNetworkMessage(self.Captains, "PlayerStatus", self.Players[SteamID], true)
-    end
 end
+
+--[[
+	Process Player Room Changes 
+]]
+function Plugin:PostJoinTeam( Gamerules, Player, OldTeam, NewTeam, Force, ShineForce )
+	if ShineForce then
+		self.Logger:Debug( "Server PostJoinTeam Force" ) 
+	end
+	
+	if not self.InProgress then return end
+	if not Player then return end
+	local PlayerName = Player:GetName()
+
+	local Client = Shine.GetClientForPlayer( Player )
+	if Client == nil then
+		return  
+	end
+
+	if NewTeam == 3 then
+		self.Logger:Debug( "Player in Spectator : %s", PlayerName )
+		self:PlayerUpdate( Client )
+		return
+	elseif NewTeam == 0 then
+		if OldTeam and OldTeam == 3 and NewTeam == 0 then
+			self.Logger:Debug( "Player out of Spectator on team %s : %s", NewTeam, PlayerName )
+			self:PlayerUpdate( Client )
+			return
+		end
+	end
+
+end
+
+
+
 
 function Plugin:SetGameState(Gamerules, State, OldState)
-    if State == kGameState.Started then
-        self:EndCaptains()
-    end
+
+	self.Logger:Debug( "Server state=========================== %s[%s] ==> %s[%s]", kGameState[OldState],OldState, kGameState[State],State)
+	--self:Notify(string.format("Server state: %s  %s", OldState, State))
+	--[[ 
+		kGameState = enum( {
+		1	'NotStarted', 
+		2	'WarmUp', 
+		3	'PreGame', 
+		4	'Countdown', 
+		5	'Started', 
+		6	'Team1Won', 
+		7	'Team2Won', 
+		8	'Draw'
+		} )
+	]]
+	
+	-- After the game has started, Verify state transition. 
+	if self.GameStarted 
+	and (State == kGameState.Team1Won or 
+        State == kGameState.Team2Won or 
+        State == kGameState.Draw)
+	then
+		self.Logger:Debug( "Server state: Captains match over." )
+		-- Okay to turn it off.
+		self.GameStarted = false
+		-- remove test bots. [this worked to remove all bots]
+		--Shared.ConsoleCommand(string.format("sv_maxbots %d", 12))
+		-- Delay MatchComplete for a few seconds for the Scores screen to appear before we reset team names.
+		Plugin:SimpleTimer( 5, function(Timer)
+			self:MatchComplete()	
+		end)
+		return
+	end
+		
+	if State == kGameState.Started 
+	and not (self.InProgress or self.GameStarted) then
+		self.Logger:Debug( "Server state: End captains if it started outside of the mod" )
+		-- End captains if it started outside of the mod
+		self:EndCaptains()
+		return	
+	end
+	
+	-- self.InProgress and 
+	
+	if State == kGameState.Started then
+		self.Logger:Trace( "Captains Mode Game Starting" )
+		self:DestroyTimer("EndCaptainsGame")
+		-- The Captains game is starting. Send the Team Notification. 
+		self.GameStarted = true
+		self:DestroyTimer("GameStartCountdown")
+		self.InProgress = false
+		
+		local MarinesTeamName
+		local AliensTeamName
+		if self.Team1IsMarines then
+			MarinesTeamName = self.dt.Team1Name
+			AliensTeamName = self.dt.Team2Name
+		else
+			MarinesTeamName = self.dt.Team2Name
+			AliensTeamName = self.dt.Team1Name
+		end
+
+		self:SendNetworkMessage(
+			nil,
+			"TeamNamesNotification",
+			{marines = MarinesTeamName, aliens = AliensTeamName},
+			true
+		)		
+
+		return		
+	end
+	
+	
+	-- we started the game, but not it has not transitioned into a "Won or Draw" state. 
+	-- Like when someone is trying to reset the game to change the starting location.
+	-- So we will create a timer to end the mod if the game doesn't start again within 60 seconds.
+	--if State == kGameState.Started then
+	if self.GameStarted 
+	and not (State == kGameState.Started or
+		State == kGameState.Team1Won or 
+        State == kGameState.Team2Won or 
+        State == kGameState.Draw)
+	 then
+		-- create a timer to end Captains if it doesn't restart within 60 seconds. 
+
+		if not (self:TimerExists( "EndCaptainsGame" )) then
+
+			self:CreateTimer( "EndCaptainsGame" , 60, 1, function(Timer)
+				self.Logger:Debug( "Ending Captains EndGame Timer Running Check..." )
+
+				-- if Picking is in Progress Stop counting.
+				if self.InProgress then return end
+				if not self.GameStarted then return end
+				
+				self.Logger:Debug( "Ending Captains mode, game did not start." )
+				-- If the time still exists in 60 seconds, end Captains.
+				self:EndCaptains()
+			end);
+			
+		end 
+		
+	end
+
 end
+
+function Plugin:OnGameReset()
+	self:Notify("Game Reset")
+end
+
+
+function Plugin:PlayerNameChange( Player, Name, OldName )
+	local Client = Shine.GetClientForPlayer( Player )
+	self.Logger:Trace( "Server PlayerNameChange from [%s] to [%s]", Name, OldName )
+	self:PlayerUpdate( Client )
+end
+
+--[[
+	Processing when a new player connects and picking is in progress.
+]]
+function Plugin:ClientConfirmConnect( Client )
+
+	if not self.InProgress then return end
+
+	self:PlayerUpdate( Client )
+	
+	local IsBot = Client:GetIsVirtual()
+	if IsBot then return end 
+
+	-- lets make sure the new player is updated.
+	for pickid, Player in pairs(self.Players) do
+		self:SendNetworkMessage(Client, "PlayerStatus", Player, true)
+	end
+
+	-- allow new player to see the team picks.	
+	if Plugin.Config.AllowPlayersToViewTeams then
+		self:SendNetworkMessage(Client , "StartCaptains", {team1marines = self.Team1IsMarines}, true)
+		--self:SendNetworkMessage(Client, "ShowTeamMenu", {}, true)
+	end
+
+end
+
 
 -- Cancel captains mode if a captain quits the game
 function Plugin:ClientDisconnect(Client)
-    local SteamID = Client:GetUserId()
-    if self.InProgress then
-        if self:GetCaptainIndex(Client) then
-            local PlayerName = Client:GetControllingPlayer():GetName()
-            self:Notify("Captains mode was cancelled because " .. PlayerName .. " has left the game.", "red")
-            self:EndCaptains()
-        end
+	local PlayerName = Shine.GetClientName( Client )
+	self.Logger:Debug( "ClientDisconnect %s.", PlayerName )
+	
+	--local IsBot = Client:GetIsVirtual()
+	--if IsBot then return end 
+ 
+	if self.InProgress then
+		local pickid = self:GetPickId(Client)
+		
+		if self:GetCaptainIndex(Client) then
+		-- something with kicking the captain is crashing the game.
+		-- To fix that we will delay this processing with a timer.
+		
+			self.Logger:Debug( "Captains mode was cancelled because %s has left the game.", PlayerName )		
+			self.Logger:Debug( "ClientDisconnect Removing Captain %s", pickid )
+			-- Throw this into a Timer, because otherwise it was causing the game to crash.
+			self:SimpleTimer( 1, function()
+				self.Logger:Debug( "Post ClientDisconnect Ending Captains")
+				self:EndCaptains()
+				self:Notify("Captains mode was cancelled because " .. PlayerName .. " has left the game.", "red")
+			end )
+			return
+		end
 
-        local Player = self.Players[SteamID]
-        Player.team = 0
-        self:SendNetworkMessage(self.Captains, "PlayerStatus", Player, true)
-    end
+		local Player = self.Players[pickid]
+		if Player ~= nil then
+			self.Logger:Debug( "ClientDisconnect Removing Player %s", Player.pickid )
+			 
+			Player.team = 5
+			Player.Client = nil
+			Player.isPickable = false
+			self:PlayerStatus( Player )
+		end
+	end
 end
 
 function Plugin:Cleanup()
-    self.BaseClass.Cleanup(self)
-    Print "Disabling server plugin..."
+	self.Logger:Info( "Disabling server plugin..." )
+	self.BaseClass.Cleanup(self)
 end
+
+
+
+
+
+
+function Plugin:TestingCaptainsInitialise()
+
+	self.TestingCaptains = false
+	self.TestingCaptainBots = nil
+	
+	--self:CreateCommands()
+
+	return true
+end
+
+function Plugin:CreateTestingCommands()
+	--[[
+		TestCaptain allow for testing the Captains mod 
+	]]
+	local function TestCaptain(Client)
+		local PlayerName = Shine.GetClientName( Client )
+		-- If there is a game in progress, deny it.
+		local Gamerules = GetGamerules()
+		if Gamerules:GetGameStarted() then
+			Shine:Notify(Client, ChatName, PlayerName, "A game has already started.")
+			return
+		end
+		if #self.Captains >= 2 then
+			Shine:Notify(Client, ChatName, PlayerName, "There are already 2 captains.")
+			return
+		end
+		
+		self.TestingCaptains = true
+		self.TestingCaptainBots = {}
+		self.Logger:Debug( "Captains mode TESTING by %s.", PlayerName )
+		self:TestingCaptainsPresetup()
+	end
+	local CaptainCommand = self:BindCommand("sh_cm_captain_test", "testcaptain", TestCaptain)
+	CaptainCommand:Help("Test captains mode.")
+end
+
+function Plugin:TestingCaptainsPresetup()
+	local GameIDs = Shine.GameIDs
+	self.Logger:Debug( "Server TestingCaptainsPresetup" )
+
+	self.InProgress = true
+	
+	if Plugin.Config.AutoRemoveBots then
+		Shared.ConsoleCommand(string.format("sv_maxbots %d", 0))
+	end
+	if Plugin.Config.AutoDisableVoteRandom then
+		Shared.ConsoleCommand("sh_disableplugin voteRandom")
+	end
+	if Plugin.Config.AutoReadyRoom then
+		--this forces everyone to the ready room
+		--Shared.ConsoleCommand("sh_rr *")
+		--Shine.mapvote:ForcePlayersIntoReadyRoom()
+		local MapVote= Shine.Plugins.mapvote
+		if MapVote and MapVote.Enabled then
+			self.Logger:Info( "Server ForcePlayersIntoReadyRoom" )
+			MapVote:ForcePlayersIntoReadyRoom()
+		end
+	end
+	self:DestroyTimer("NeedOneMoreCaptain")
+	
+	-- Add 12 more bots for testing. We need the bots to add now so they get Ids generated in PlayerUpdate.
+	--Shared.ConsoleCommand(string.format("addbot %d", 12))
+	self.Logger:Debug( "TestingCaptains: Add Bots for picking")
+	OnConsoleAddBots( nil, 12 )
+	self.Logger:Debug( "TestingCaptains: 12 Bots Added")
+	-- Testing with Commander bots, I need this to remove them after the game is over.
+	Gamerules.removeCommanderBots = true
+	-- We need to wait for the bots to be added before we continue.
+	-- Run the next steps with a Simple timer
+	
+	-- OnConsoleAddBots( nil, 1, TeamNumber, "com" )
+	
+	local function AddTestCaptain(Client)
+		local IsBot = Client:GetIsVirtual()
+		if not IsBot then return end
+		
+		if #self.Captains < 2 then
+			local PlayerName = Shine.GetClientName(Client)
+			local team = #self.Captains + 1
+			local team2 = (team % 2 ) + 1
+			self.Logger:Debug( "Adding bot captain %s for team : %s", PlayerName, team )
+			table.insert(self.Captains, Client)
+			self.TestingCaptainBots[team] = Client
+			-- Find the bot by name, and set their team 
+			for pickid, botCheck in pairs(self.Players) do
+				if botCheck.name == PlayerName then
+					botCheck.pick = team
+					botCheck.isCaptain = true
+					break	
+				end 
+			end
+			self:PlayerUpdate( Client )
+		end
+		
+	end
+	
+	-- Wait for all the bots to Load and Generate Names. Then make one of them Captain and start the picking.
+	self:SimpleTimer( 2, function()
+		self.Logger:Debug( "TestingCaptains: Adding Bot Captains")
+		local GameIDs = Shine.GameIDs
+		-- We need to set one or two of the Bots as Captains  
+		for Client, ID in GameIDs:Iterate() do
+			local rc = AddTestCaptain( Client )
+			if #self.Captains < 2 then
+			else
+				break
+			end
+		end
+		
+		self:StartCaptains()
+		self:TestingCaptainsAddTimers()
+	end )	
+
+end
+
+function Plugin:TestingCaptainsAddTimers()
+	if not self.TestingCaptains then return end
+	
+	for team = 1, 2 do
+		local team = self:GetCaptainIndex(self.TestingCaptainBots[team])
+		if team ~= nil then
+			local team2 = (team % 2) + 1
+		
+			local timerName = string.format("AutoPickTeam_%d", team)
+			self.Logger:Debug( "TestingCaptains: Adding Bot Captain timer %s", timerName)
+			
+			self:CreateTimer(
+			timerName,
+			 2,
+			-1,
+			function (Timer)
+				if self.dt.CaptainTurn == 0 then return end
+				
+				if self.dt.CaptainTurn ~= team then
+					if self.Ready[team2] == true then
+					 	self.Logger:Debug( "Bot Captain team : %s Ready", team)
+						self:Notify( string.format( "Bot Captain team : %s Ready", team) , "green")
+						self.Ready[team] = true
+						self:DestroyTimer(timerName) 
+					end
+					return 
+				end
+				
+				for pickid, Player in pairs(self.Players) do
+					if Player.pick == 0 then
+						self.Logger:Debug( "Bot Captain team : %s picking %s", team, Player.name )
+						self:ReceivePickPlayer( self.Captains[team], {pickid = Player.pickid})
+						return
+					end
+				end
+				self.Logger:Debug( "Bot Captain team : %s Ready", team)
+				self:Notify( string.format( "Bot Captain team : %s Ready", team) , "green")
+				self.Ready[team] = true
+				self:DestroyTimer(timerName)
+				return
+			end)
+			
+		end		
+	end
+				
+end
+
+
+
+
+Shine.LoadPluginModule( "logger.lua", Plugin )

--- a/lua/shine/extensions/captainsmode/server.lua
+++ b/lua/shine/extensions/captainsmode/server.lua
@@ -15,13 +15,6 @@ local StringFormat = string.format
 local tostring = tostring
 
 
-Plugin.Conflicts = {
-	DisableThem = {
-		"voterandom"
-	}
-}
-
-
 -- Block these votes when Captains Mode is running.
 Plugin.BlockedEndOfMapVotes = {
 	--VoteResetGame = true,
@@ -378,13 +371,7 @@ function Plugin:StartCaptainsPresetup()
 		Shared.ConsoleCommand(string.format("sv_maxbots %d", 0))
 	end
 	if Plugin.Config.AutoDisableVoteRandom then
-		--[[
-			trying instead of this. Plugin.Conflicts.DisableThem
-			This didn't really work anyway
-		]]
-		-- diable the plugin that auto random teams at start.?
-		-- no : Shared.ConsoleCommand("sh_disableplugin voteRandom")
-		-- yes: Shared.ConsoleCommand("sh_unloadplugin voteRandom")
+		Shared.ConsoleCommand("sh_unloadplugin voterandom")
 	end
 	if Plugin.Config.AutoReadyRoom then
 		--this forces everyone to the ready room
@@ -680,9 +667,7 @@ function Plugin:EndCaptains()
 		Shared.ConsoleCommand(string.format("sv_maxbots %d", 12))
 	end
 	if Plugin.Config.AutoDisableVoteRandom then
-	-- sh_loadplugin & sh_unloadplugin
-		Shared.ConsoleCommand("sh_enableplugin voteRandom")
-		--Shared.ConsoleCommand("sh_loadplugin voteRandom")
+		Shared.ConsoleCommand("sh_loadplugin voterandom")
 	end
 	if Plugin.Config.AutoDisableSelf then
 		--Shared.ConsoleCommand("sh_disableplugin captainsmodeharq")
@@ -1148,7 +1133,7 @@ function Plugin:TestingCaptainsPresetup()
 		Shared.ConsoleCommand(string.format("sv_maxbots %d", 0))
 	end
 	if Plugin.Config.AutoDisableVoteRandom then
-		Shared.ConsoleCommand("sh_disableplugin voteRandom")
+		Shared.ConsoleCommand("sh_unloadplugin voterandom")
 	end
 	if Plugin.Config.AutoReadyRoom then
 		--this forces everyone to the ready room

--- a/lua/shine/extensions/captainsmode/shared.lua
+++ b/lua/shine/extensions/captainsmode/shared.lua
@@ -1,16 +1,28 @@
-local Plugin = {}
-Plugin.Version = "0.9.2"
+--[[
+	Captains Mode
+]]
+
+local Plugin = Shine.Plugin( ... )
+
+Plugin.Version = "0.10.1"
 Plugin.HasConfig = true
 Plugin.ConfigName = "CaptainsMode.json"
 
 Plugin.DefaultConfig = {
-    AutoRemoveBots = true,
-    AutoDisableVoteRandom = true,
-    AutoReadyRoom = true,
-    AutoDisableSelf = true,
-    AnnouncePlayerNames = true,
-    ShowMarineAlienToCaptains = true,
-    CountdownSeconds = 60
+	AllowTesting = false,
+	AutoRemoveBots = true,
+	AutoDisableVoteRandom = true,
+	AutoReadyRoom = true,
+	AutoDisableSelf = false,
+	AnnouncePlayerNames = true,
+	AllowPlayersToViewTeams = true,
+	ShowMarineAlienToCaptains = true,
+	CountdownSeconds = 60,
+	LogLevel = "INFO"
+}
+
+Plugin.NotifyPrefixColour = {
+	131, 0, 255
 }
 
 Plugin.CheckConfig = true
@@ -19,30 +31,58 @@ Plugin.CheckConfigRecursively = false
 Plugin.DefaultState = false
 Plugin.NS2Only = true
 
-function Plugin:SetupDataTable()
-    -- team: 0 = unavailable for picking, 1 = team 1, 2 = team 2, 3 = available for picking
-    local PlayerStatus = {
-        steamid = "string (255)",
-        name = "string (255)",
-        skill = "integer",
-        team = "integer"
-    }
-    self:AddNetworkMessage("PlayerStatus", PlayerStatus, "Client")
+local TeamDisconnect = "Disconnected"
 
-    self:AddNetworkMessage("PickPlayer", {steamid = "string (255)"}, "Server")
-    self:AddNetworkMessage("CaptainTurn", {turn = "boolean"}, "Client")
-
-    self:AddNetworkMessage("StartCaptains", {team1marines = "boolean"}, "Client")
-    self:AddNetworkMessage("EndCaptains", {}, "Client")
-    self:AddNetworkMessage("RequestEndCaptains", {}, "Server")
-
-    self:AddNetworkMessage("SetTeamName", {teamname = "string (255)"}, "Server")
-    self:AddNetworkMessage("TeamName", {team = "integer", teamname = "string (255)"}, "Client")
-    self:AddNetworkMessage("SetReady", {ready = "boolean"}, "Server")
-
-    self:AddNetworkMessage("PickNotification", {text = "string (255)"}, "Client")
-    self:AddNetworkMessage("TeamNamesNotification", {marines = "string (255)", aliens = "string (255)"}, "Client")
-    self:AddNetworkMessage("CountdownNotification", {text = "string (255)"}, "Client")
+function Plugin:GetTeamName( Team, Capitals, Singular )
+	if Team > 4 then
+		return TeamDisconnect	 
+	end
+	return Shine:GetTeamName( Team, Capitals, Singular )
 end
 
-Shine:RegisterExtension("captainsmode", Plugin)
+function Plugin:SetupDataTable()
+	-- team: 0 = unavailable for picking, 1 = team 1, 2 = team 2, 3 = available for picking
+	local PlayerStatus = {
+		pickid = "string (32)",
+		steamid = "integer",
+		name = "string (255)",
+		skill = "integer",
+		skilloffset = "integer",
+		team = "integer",
+		pick = "integer",
+		isPickable = "boolean",
+		isCaptain= "boolean"
+	}
+	
+	self:AddDTVar( "string (255)", "Team1Name", "Marines" )
+	self:AddDTVar( "string (255)", "Team2Name", "Aliens" )
+	self:AddDTVar( "integer", "CaptainTurn", "0" )
+
+	self:AddNetworkMessage("PlayerStatus", PlayerStatus, "Client")
+
+	self:AddNetworkMessage("PickPlayer", {pickid = "string (32)"}, "Server")
+	self:AddNetworkMessage("TradePlayer", {pickid = "string (32)"}, "Server")
+
+	self:AddNetworkMessage("StartCaptains", {team1marines = "boolean"}, "Client")
+	self:AddNetworkMessage("EndCaptains", {}, "Client")
+	self:AddNetworkMessage("CaptainsMatchStart", {}, "Client")
+	self:AddNetworkMessage("CaptainsMatchComplete", {}, "Client")
+	
+	self:AddNetworkMessage("RequestEndCaptains", {}, "Server")
+	
+	self:AddNetworkMessage("SetTeamName", {teamname = "string (255)"}, "Server")
+	self:AddNetworkMessage("TeamName", {team = "integer", teamname = "string (255)"}, "Client")
+	self:AddNetworkMessage("SetReady", {ready = "boolean"}, "Server")
+	self:AddNetworkMessage("UnsetReady", {}, "Client")
+
+	self:AddNetworkMessage("PickNotification", {text = "string (255)"}, "Client")
+	self:AddNetworkMessage("TeamNamesNotification", {marines = "string (255)", aliens = "string (255)"}, "Client")
+	self:AddNetworkMessage("CountdownNotification", {text = "string (255)"}, "Client")
+	
+	self:AddNetworkMessage("ShowTeamMenu", {}, "Client")
+	self:AddNetworkMessage("HideMouse", {}, "Client")
+	
+end
+
+
+return Plugin


### PR DESCRIPTION
Here are the list of fixes with this update:

1. used MapVote to force Alien/Marines to the readyroom
2. Block players from joining teams while picking is active.
3. Track players joining spec and back to RR without losing pick
4. It might allow a pick to rejoin the server and still be a pick. hard to test by yourself.
5. Window UI refreshes without redrawing ui every time.
6. Allow everyone to View teams as picking occurs.
7. Changed "Team Name" to be input field on Teams view instead of button and popup.
8. added a few sounds for fun
9. Always announce team names when game starts.
10. If the mod is active that starts the game after two captains enter the chair, the Team Names still appears.
11. Unload voterandom and Captain Picking Start.  Load voterandom when Captains is complete.
12. Added Vote Blocks for:  RandomRR, ForceEvenTeams, ChangeMap, AddCommBots
13. After teams are picked. I added a check for any unavailable players and then remove them from the teams. Captains are then forced to Ready up again. 
14. Added Player Trading on "Teams" window to try to balance teams after picking is done, before ready.
15. Show Alien and Marine Skill on Pick. 
16. Show Team's skill on Team Window.
17. Added Tooltip to show both skills on Team window
18. Allow the Tab/TEAMSCORES window to appear and hide the Captains Window.