### PR TITLE
Rematch and Captains

### DIFF
--- a/locale/shine/extensions/captainsmode/enGB.json
+++ b/locale/shine/extensions/captainsmode/enGB.json
@@ -7,6 +7,8 @@
 	"CAPTAINS_NOTIFY_DISABLED": "Captains mode has been disabled.",
 	"CAPTAINS_AUTODISABLE_ENABLED": "Captains Auto Disable has been enabled.",
 	"CAPTAINS_AUTODISABLE_DISABLED": "Captains Auto Disable has been disabled.",
+	"CAPTAINS_NIGHT_ENABLED": "Captains Night has been enabled.",
+	"CAPTAINS_NIGHT_DISABLED": "Captains Night has been disabled.",	
 
 	"NOTIFY_PREFIX": "[Captains Mode]",
 	"SPECTATOR_TO_CAPTAIN": "Spectators not allowed to Captain.",

--- a/lua/shine/extensions/captainsmode/shared.lua
+++ b/lua/shine/extensions/captainsmode/shared.lua
@@ -10,6 +10,7 @@ Plugin.ConfigName = "CaptainsMode.json"
 
 Plugin.DefaultConfig = {
 	Captains = false,
+	CaptainsNight = false,
 	AllowTesting = false,
 	AutoRemoveBots = true,
 	AutoDisableVoteRandom = true,
@@ -18,6 +19,7 @@ Plugin.DefaultConfig = {
 	AnnouncePlayerNames = true,
 	AllowPlayersToViewTeams = true,
 	ShowMarineAlienToCaptains = true,
+	ShowMarineAlienToPlayers = true,
 	CountdownSeconds = 60,
 	LogLevel = "INFO",
 	BlockedVotesMinPlayer = 12
@@ -58,6 +60,8 @@ function Plugin:SetupDataTable()
 
 	self:AddDTVar( "boolean", "Captains", false )
 	self:AddDTVar( "boolean", "Suspended", false )
+	self:AddDTVar( "boolean", "CaptainsNight", false )
+	self:AddDTVar( "boolean", "TestingCaptains", false )
 	self:AddDTVar( "string (255)", "Team1Name", "Marines" )
 	self:AddDTVar( "string (255)", "Team2Name", "Aliens" )
 	self:AddDTVar( "integer (0 to 2)", "CaptainTurn", "0" )
@@ -67,6 +71,10 @@ function Plugin:SetupDataTable()
 	self:AddNetworkMessage("PickPlayer", {pickid = "string (32)"}, "Server")
 	self:AddNetworkMessage("TradePlayer", {pickid = "string (32)"}, "Server")
 
+	self:AddNetworkMessage("RequestSwapTeams", {team = 'integer (0 to 2)', settings="boolean"}, "Server")
+	self:AddNetworkMessage("TeamSwapRequested", {team = 'integer (0 to 2)'}, "Client")
+	self:AddNetworkMessage("SwapTeams", {team1marines = "boolean"}, "Client")
+
 	self:AddNetworkMessage("StartCaptains", {team1marines = "boolean"}, "Client")
 	self:AddNetworkMessage("EndCaptains", {}, "Client")
 	self:AddNetworkMessage("CaptainsMatchStart", {}, "Client")
@@ -74,8 +82,8 @@ function Plugin:SetupDataTable()
 
 	self:AddNetworkMessage("RequestEndCaptains", {}, "Server")
 
-	self:AddNetworkMessage("SetTeamName", {teamname = "string (255)"}, "Server")
-	self:AddNetworkMessage("SetReady", {ready = "boolean"}, "Server")
+	self:AddNetworkMessage("SetTeamName", {team = 'integer (0 to 2)', teamname = "string (255)", settings="boolean"}, "Server")
+	self:AddNetworkMessage("SetReady", {ready = "boolean", team = 'integer (0 to 2)', settings="boolean"}, "Server")
 	self:AddNetworkMessage("UnsetReady", {}, "Client")
 
 	self:AddNetworkMessage("PickNotification", {text = "string (255)"}, "Client")
@@ -101,6 +109,12 @@ function Plugin:SetupDataTable()
 	self:AddTranslatedError( "JOIN_TEAMS_CAPTAINS_NIGHT", { 
 		team = self:GetNameNetworkField()
 	} )	
+
+	local CaptainOptions = {
+		ShowSettings = "boolean"
+	}
+	self:AddNetworkMessage( "CaptainOptions" , CaptainOptions, "Client" )
+	self:AddNetworkMessage( "RequestCaptainOptions" , {}, "Server" )
 
 end
 

--- a/lua/shine/extensions/rematch/client.lua
+++ b/lua/shine/extensions/rematch/client.lua
@@ -33,9 +33,7 @@ function Plugin:ResetState()
 	self.TeamNames = {"Marines", "Aliens"}
 	--self.CaptainNames = {"One","Two"}
 	self:ResetTeamNames( )
-
 	self.MatchStart = false
-	self.ClientInProgress = false
 
 end
 
@@ -60,7 +58,6 @@ function Plugin:Cleanup()
 	self.BaseClass.Cleanup(self)
 end
 
-
 function Plugin:ReceiveRematchMatchStart(Data)
 	self.Logger:Debug( "ReceiveRematchMatchStart" )
 	-- when the match starts.. remove stuff.
@@ -77,8 +74,6 @@ function Plugin:ReceiveRematchEnd(Data)
 	self:ResetState()
 end
 
-
-
 function Plugin:OnFirstThink()
 	self:CallModuleEvent("OnFirstThink")
 	self.Delay = 0.5
@@ -90,7 +85,6 @@ function Plugin:OnFirstThink()
 	Shine.Hook.SetupClassHook( "GUIScoreboard", "UpdateTeam", "Rematch_GUIScoreboardUpdateTeam", "PassivePost")
 
 end
-
 
 function Plugin:OnSuspend()
 	--self:Disable()
@@ -135,12 +129,8 @@ function Plugin:Think( DeltaTime )
 
 end
 
-
-
 function Plugin:Rematch_GUIScoreboardUpdateTeam(  scoreboard, updateTeam  )
 	if self.dt.Suspended then return end
-
-	--Plugin._GUIScoreboardUpdateTeam(scoreboard, updateTeam)
 	local teamNameGUIItem = updateTeam["GUIs"]["TeamName"]
 	local teamScores = updateTeam["GetScores"]()
 	local teamNumber = updateTeam["TeamNumber"]
@@ -151,21 +141,11 @@ function Plugin:Rematch_GUIScoreboardUpdateTeam(  scoreboard, updateTeam  )
 	local originalHeaderText = teamNameGUIItem:GetText()
 	local newTeamName = self.TeamNames[teamNumber]
 	local teamHeaderText
-
 	local teamNameText = Locale.ResolveString(string.format("NAME_TEAM_%s", updateTeam["TeamNumber"]))
 	teamHeaderText = string.gsub(originalHeaderText, teamNameText, newTeamName )
-
---	-- How many items per player.
---	local numPlayers = table.icount(teamScores)
---	-- Update the team name text.
---	local playersOnTeamText = string.format("%d %s", numPlayers, numPlayers == 1 and Locale.ResolveString("SB_PLAYER") or Locale.ResolveString("SB_PLAYERS"))
---	local teamHeaderText
---	teamHeaderText = string.format("%s (%s)", teamNameText, playersOnTeamText)
-
 	teamNameGUIItem:SetText(teamHeaderText)
 
 end
-
 
 function Plugin:ReceiveCountdownNotification(Data)
 	Shine.ScreenText.Add(

--- a/lua/shine/extensions/rematch/shared.lua
+++ b/lua/shine/extensions/rematch/shared.lua
@@ -20,10 +20,11 @@ Plugin.DefaultConfig = {
 	CountdownSeconds = 60,
 	BlockedVotesMinPlayer = 12,
 	AllowTesting = false,
-	AutoDisableSelf = false,
+	AutoDisableSelf = true,
 		-- AutoRemoveBots = true,
 		-- AutoReadyRoom = true,
-
+	RestoreTeamHistoryAfterMapchange = true,
+	TeamHistoryLifeTime = 300, -- max amount of time the history is preserved after a mapchange. Increase/decrease this value based on server loading time
 }
 
 Plugin.NotifyPrefixColour = {


### PR DESCRIPTION
### Rematch
Add team history for rematching prior games.
Updated commands to make them easier to use.
Added rematchhelp for info.

### Captains
Added Team Swap Requests.
Added "Skill" column to team pick list.
Added "Settings" tab for Admins to assist in some Captains features.
Added config to allow Players to see which team is Aliens or Marines.
Updated "CaptainsNight" command and processing to make it persisent across map changes.
Running "captainsnight" command will now always activate captainsnight by default.
To turn off captainsnight you will need to run "captainsnight disable"