### PR TITLE
Updates for Joining Teams

### DIFF
--- a/locale/shine/extensions/captainsmode/enGB.json
+++ b/locale/shine/extensions/captainsmode/enGB.json
@@ -8,7 +8,7 @@
 	"CAPTAINS_AUTODISABLE_ENABLED": "Captains Auto Disable has been enabled.",
 	"CAPTAINS_AUTODISABLE_DISABLED": "Captains Auto Disable has been disabled.",
 	"CAPTAINS_NIGHT_ENABLED": "Captains Night has been enabled.",
-	"CAPTAINS_NIGHT_DISABLED": "Captains Night has been disabled.",	
+	"CAPTAINS_NIGHT_DISABLED": "Captains Night has been disabled.",
 
 	"NOTIFY_PREFIX": "[Captains Mode]",
 	"SPECTATOR_TO_CAPTAIN": "Spectators not allowed to Captain.",
@@ -27,5 +27,8 @@
 	"CAPTAINS_FIRST_PICK": "[Captains Mode] {CaptainName} picks first.",
 	"JOIN_TEAMS_BLOCKED" : "Not allowed to join {team} while captains picking is active.",
 	"JOIN_TEAMS_CAPTAINS_NIGHT" : "Not allowed to join {team} while Captains Night is active.",
-	"CAPTAINS_LASTTEAMS":"Last Teams have been set."
+	"CAPTAINS_LASTTEAMS":"Last Teams have been set.",
+	"CAPTAINS_NIGHT_GAMESTARTED" : "Captains Night Started - Team Joining allowed until match ends.",
+	"CAPTAINS_NIGHT_TEAM_BLOCK" : "Captains Night Started - Team Joining is blocked.",
+	"CAPTAINS_NIGHT_ENDED" : "Captains Night Ended - Team Joining is allowed."
 }

--- a/lua/shine/extensions/captainsmode/shared.lua
+++ b/lua/shine/extensions/captainsmode/shared.lua
@@ -4,7 +4,7 @@
 
 local Plugin = Shine.Plugin( ... )
 
-Plugin.Version = "0.10.1"
+Plugin.Version = "0.10.2"
 Plugin.HasConfig = true
 Plugin.ConfigName = "CaptainsMode.json"
 
@@ -22,7 +22,8 @@ Plugin.DefaultConfig = {
 	ShowMarineAlienToPlayers = true,
 	CountdownSeconds = 60,
 	LogLevel = "INFO",
-	BlockedVotesMinPlayer = 12
+	BlockedVotesMinPlayer = 12,
+	JoinTeamBlockDelay = 5
 }
 
 Plugin.NotifyPrefixColour = {

--- a/lua/shine/extensions/captainsmode/shared.lua
+++ b/lua/shine/extensions/captainsmode/shared.lua
@@ -23,7 +23,7 @@ Plugin.DefaultConfig = {
 	CountdownSeconds = 60,
 	LogLevel = "INFO",
 	BlockedVotesMinPlayer = 12,
-	JoinTeamBlockDelay = 5
+	JoinTeamBlockDelay = 300
 }
 
 Plugin.NotifyPrefixColour = {


### PR DESCRIPTION
Stop blocking bots from joining teams.
Added JoinTeamBlockDelay seconds to config.
Updated to allow people to join active games after the delay.